### PR TITLE
do R_ProcessEvents in rniIdle if Windows

### DIFF
--- a/jri/src/Rengine.c
+++ b/jri/src/Rengine.c
@@ -318,7 +318,9 @@ JNIEXPORT jint JNICALL Java_org_rosuda_JRI_Rengine_rniExpType
 JNIEXPORT void JNICALL Java_org_rosuda_JRI_Rengine_rniIdle
   (JNIEnv *env, jobject this)
 {
-#ifndef Win32
+#ifdef Win32
+	if(!UserBreak)R_ProcessEvents();
+#else
     R_runHandlers(R_InputHandlers, R_checkActivity(0, 1));
 #endif
 }


### PR DESCRIPTION
Windows' graphic device (windows()) and pager freezes when waiting console user input, because Windows console, graphics device, pager share the same thread for event processing.

rniIdle is to called frequently when waiting console user input. So I added event processing for Windows in rniIdle function.

It seems like interrupted handling don't work in rniIdle so I avoided interrupted case(UserBreak).
