### PR TITLE
change .C -> .Call when calling RJavaCheckExceptions

### DIFF
--- a/R/call.R
+++ b/R/call.R
@@ -323,7 +323,7 @@ is.jnull <- function(x) {
   else
     try(a <- .jcall("java/lang/Class","Ljava/lang/Class;","forName",cl,check=FALSE))
   # this is really .jcheck but we don't want it to appear on the call stack
-  .C(RJavaCheckExceptions, silent, FALSE, PACKAGE = "rJava")
+  .Call(RJavaCheckExceptions, silent)
   if (!silent && is.jnull(a)) stop("class not found")
   a
 }


### PR DESCRIPTION
The function rJava::.jfindClass contains the expression
.C(RJavaCheckExceptions, silent, FALSE, PACKAGE = "rJava").  I think
this is an error, since the C function RJavaCheckExceptions is defined
with signature "SEXP RJavaCheckExceptions(SEXP silent)", and it is
called via .Call in .jcheck.  I suspect that it is a fluke that this
works in R without crashing: perhaps because the argument 'silent' is
not manipulated much.

My suggested fix is to change .jfindClass to call RJavaCheckExceptions
via .Call, like .jcheck does.
