### PR TITLE
Workaround for Oracle JVM to detect, recover from and prevent shrinking of R stack

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -434,7 +434,7 @@ extern int R_CStackDir;
 */
 
 volatile int globald = 0;
-static void* findBound(char *from, char *limit, int dir)
+static char* findBound(char *from, char *limit, int dir)
 {
   int pipefd[2];
   pid_t cpid;
@@ -580,8 +580,8 @@ static SEXP RinitJVM_jsw(SEXP par) {
 
   _dbg(rjprintf("  R_CStackStart %p\n", R_CStackStart));
   _dbg(rjprintf("  R_CStackLimit %lu\n", (unsigned long)R_CStackLimit));
-  void *maxBound = (void *)((intptr_t)R_CStackStart - (intptr_t)R_CStackDir*rlimsize);
-  void *oldBound = findBound((void*)R_CStackStart - R_CStackDir, maxBound, -R_CStackDir);
+  char *maxBound = (char *)((intptr_t)R_CStackStart - (intptr_t)R_CStackDir*rlimsize);
+  char *oldBound = findBound((char*)R_CStackStart - R_CStackDir, maxBound, -R_CStackDir);
   _dbg(rjprintf("  maxBound %p\n", maxBound));
   _dbg(rjprintf("  oldBound %p\n", oldBound));
 
@@ -606,7 +606,7 @@ static SEXP RinitJVM_jsw(SEXP par) {
 
   if (val >= JSW_DETECT) {
 
-    void *newBound = findBound((void*)R_CStackStart - R_CStackDir, oldBound, -R_CStackDir);
+    char *newBound = findBound((char*)R_CStackStart - R_CStackDir, oldBound, -R_CStackDir);
     _dbg(rjprintf("  newBound %p\n", newBound));
     if (oldBound == newBound) {
       /* No guard pages inserted, keep the original stack size.

--- a/src/init.c
+++ b/src/init.c
@@ -388,8 +388,8 @@ static SEXP RinitJVM_real(SEXP par)
    limit is implemented in os::Linux::capture_initial_stack (the limit 4M on
    Itanium which is ignored here by rJava and 2M on other Linux systems) and
    is claimed to be a workaround for issues in RH7.2.  The problem is still
-   present in JVM 9.  Moreover, on Linux the JVM inserts also guard pages
-   also based on the setting of -Xss.
+   present in JVM 9.  Moreover, on Linux the JVM inserts guard pages also
+   based on the setting of -Xss.
 */
 
 #undef JVM_STACK_WORKAROUND
@@ -577,8 +577,8 @@ static SEXP RinitJVM_jsw(SEXP par) {
   _dbg(rjprintf("  oldBound %p\n", oldBound));
 
   /* it is expected that newBound < maxBound, because not all of the "rlim"
-     stack is accessible even before JVM initialization, which can be e.g.
-     because of imprecise detection of the stack start */
+     stack may be accessible even before JVM initialization, which can be e.g.
+     because of an imprecise detection of the stack start */
 
   intptr_t padding = 0;
   if (val >= JSW_PREVENT) {
@@ -617,9 +617,9 @@ static SEXP RinitJVM_jsw(SEXP par) {
       _dbg(rjprintf("  new R_CStackLimit %lu\n", (unsigned long)R_CStackLimit));
     }
 
-    /* Only report when the loss is big. There will always be some bytes
+    /* Only report when the loss is big. There may be some bytes
        lost because even with the original setting of R_CStackLimit before
-       initializing the JVM, one cannot access all bytes of stack
+       initializing the JVM, one may not be able to access all bytes of stack
        (e.g. because of imprecise detection of the stack start). */
 
     int bigloss = 0;

--- a/src/init.c
+++ b/src/init.c
@@ -254,9 +254,8 @@ HIDE void init_rJava(void) {
   rJava_initialized = 1;
 }
 
-/** RinitJVM(classpath)
-    initializes JVM with the specified class path */
-REP SEXP RinitJVM(SEXP par)
+
+static SEXP RinitJVM_real(SEXP par)
 {
   const char *c=0;
   SEXP e=CADR(par);
@@ -364,6 +363,274 @@ REP SEXP RinitJVM(SEXP par)
   INTEGER(e)[0]=r;
   UNPROTECT(1);
   return e;
+}
+
+/* This is a workaround for another workaround in Oracle JVM.  On Linux, the
+   JVM would insert protected guard pages into the C stack of the R process
+   that initializes the JVM, thus effectively reducing the stack size.
+   Worse yet, R does not find out about this and fails to detect infinite
+   recursion. Without the workaround, this code crashes R after .jinit() is called
+
+   x <- 1; f <- function() { x <<- x + 1 ; print(x) ; f() } ; tryCatch(f(), error=function(e) x)
+
+   and various packages fail/segfault unpredictably as they reach the stack
+   limit.
+
+   This workaround in rJava can detect the reduction of the R stack and can
+   adjust R_CStack* variables so that the detection of infinite recursion
+   still works.  Moreover, the workaround in rJava can prevent significant
+   shrinking of the stack by allocating at least 2M from the C stack before
+   initializing the JVM.  This makes the JVM think that the current thread
+   is actually not the initial thread (os::Linux::is_initial_thread()
+   returns false), because is_initial_thread will run outside what the JVM
+   assumes is the stack for the initial thread (the JVM caps the stack to
+   2M).  Consequently, the JVM will not install guard pages.  The stack size
+   limit is implemented in os::Linux::capture_initial_stack (the limit 4M on
+   Itanium which is ignored here by rJava and 2M on other Linux systems) and
+   is claimed to be a workaround for issues in RH7.2.  The problem is still
+   present in JVM 9.  Moreover, on Linux the JVM inserts also guard pages
+   also based on the setting of -Xss.
+*/
+
+#undef JVM_STACK_WORKAROUND
+#if defined(linux) || defined(__linux__) || defined(__linux)
+#define JVM_STACK_WORKAROUND
+#endif
+
+#ifdef JVM_STACK_WORKAROUND
+
+#include <stdint.h>
+
+ /* unfortunately this needs (write!) access to R internals */
+extern uintptr_t R_CStackLimit;
+extern uintptr_t R_CStackStart;
+extern int R_CStackDir;
+
+#include <sys/types.h>
+#include <sys/time.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/resource.h>
+
+/*
+  Find a new limit for the C stack, within the existing limit.  Looks for
+  the first address in the stack area that is not accessible to the current
+  process.  This code could easily be made to work on different Unix
+  systems, not just on Linux, but it does not seem necessary at the moment.
+
+  limit is the first address not to access
+  bound is the new first address not to access
+  dir is 1 (stack grows up) or -1 (stack grows down, the usual)
+    so, incrementing by dir one traverses from stack start, from the oldest
+    things on the stace; note that in R_CStackDir, 1 means stack grows down
+
+  returns NULL in case of error, limit when no new limit is found,
+    a new limit when found
+*/
+static void* findBound(char *from, char *limit, int dir)
+{
+  int pipefd[2];
+  pid_t cpid;
+    /* any positive size could be used, using page size is a heuristic */
+  size_t psize = sysconf(_SC_PAGESIZE);
+  char buf[psize];
+
+  if (pipe(pipefd) == -1)
+    return NULL; /* error */
+
+  cpid = fork();
+  if (cpid == -1)
+    return NULL; /* error */
+
+  if (cpid == 0) {
+    /* child process, reads from the pipe */
+    close(pipefd[1]);
+
+    while (read(pipefd[0], &buf, psize) > 0);
+    _exit(0);
+  } else {
+    /* Parent process, writes data to the pipe looking for EFAULT error which
+       indicates an inaccesible page. For performance, the reading is first
+       done using a buffer (of the size of a page), but once EFAULT is reached,
+       it is re-tried byte-by-byte for the last buffer not read successfully.
+    */
+    close(pipefd[0]);
+    int failed = 0;
+
+    for(;(limit - from) * dir > 0; from += dir * psize)
+      if (write(pipefd[1], from, psize) == -1) {
+        if (errno == EFAULT) {
+          /* now proceed byte by byte */
+          for(from -= dir * psize; from != limit; from += dir)
+            if (write(pipefd[1], from, 1) == -1) {
+              if (errno != EFAULT)
+                failed = 1;
+              break;
+            }
+        } else
+          failed = 1;
+        break;
+      }
+
+    close(pipefd[1]);
+    wait(NULL);
+    return failed ? NULL : from;
+  }
+}
+
+/* Add certain amount of padding to the C stack before invoking RinitJVM.
+   The recursion turned out more reliable in face of compiler optimizations
+   than allocating large arrays on the C stack, both via definition and
+   alloca. */
+static SEXP RinitJVM_with_padding(SEXP par, intptr_t padding, char *last) {
+  char dummy[1];
+    /* reduce the risk that dummy will be optimized out */
+  dummy[0] = (char) (uintptr_t) &dummy;
+  padding -= (last - dummy) * R_CStackDir;
+  if (padding <= 0)
+    return RinitJVM_real(par);
+  else
+    return RinitJVM_with_padding(par, padding, dummy);
+}
+
+/* Run RinitJVM with the Java stack workaround */
+static SEXP RinitJVM_jsw(SEXP par) {
+
+  /* One can disable the workaround using environment variable
+     RJAVA_JVM_STACK_WORKAROUND
+
+     this support exists for diagnostics and as a way to disable the
+     workaround without re-compiling rJava.  In normal cases it only makes
+     sense to use the default value of 3.
+   */
+
+  #define JSW_DISABLED 0
+  #define JSW_DETECT   1
+  #define JSW_ADJUST   2
+  #define JSW_PREVENT  3
+
+  #define JSW_PADDING 2*1024*1024
+  #define JSW_CHECK_BOUND 16*1024*1024
+
+  /* 0 - disabled
+     1 - detect guard pages
+     2 - detect guard pages and adjust R stack size
+     3 - prevent guard page creation, detect, and adjust */
+  int val = JSW_PREVENT;
+  char *vval = getenv("RJAVA_JVM_STACK_WORKAROUND");
+  if (vval != NULL)
+    val = atoi(vval);
+  if (val < 0 || val > 3)
+    error("Invalid value for RJAVA_JVM_STACK_WORKAROUND");
+
+  if (val == JSW_DISABLED)
+    return RinitJVM_real(par);
+
+  /* Figure out the original stack limit */
+  uintptr_t rlimsize = 0;
+
+  struct rlimit rlim;
+  if (getrlimit(RLIMIT_STACK, &rlim) == 0) {
+    rlim_t lim = rlim.rlim_cur;
+    if (lim != RLIM_INFINITY)
+      rlimsize = (uintptr_t)lim;
+  }
+
+  if (rlimsize == 0 && R_CStackLimit != -1)
+    /* getrlimit should work on linux, so this should only happen
+       when stack size is unlimited */
+    rlimsize = (uintptr_t) (R_CStackLimit / 0.95);
+
+  if (rlimsize == 0 || rlimsize > JSW_CHECK_BOUND)
+    /* use a reasonable limit when looking for guard pages when
+       stack size is unlimited or very large  */
+    rlimsize = JSW_CHECK_BOUND;
+
+  void *maxBound = (void *)((intptr_t)R_CStackStart - (intptr_t)R_CStackDir*rlimsize);
+  void *oldBound = findBound((void*)R_CStackStart, maxBound, -R_CStackDir);
+
+  /* it is expected that newBound < maxBound, because not all of the "rlim"
+     stack is accessible even before JVM initialization */
+
+  intptr_t padding = 0;
+  if (val >= JSW_PREVENT) {
+    int dummy;
+    intptr_t usage = R_CStackDir * (R_CStackStart - (uintptr_t)&dummy);
+    usage += JSW_PADDING + 512; /* 512 is a buffer for C recursive calls */
+    if(R_CStackLimit == -1 || usage < ((intptr_t) R_CStackLimit))
+      padding = JSW_PADDING;
+  }
+
+  char dummy[1];
+    /* reduce the risk that dummy will be optimized out */
+  dummy[0] = (char) (uintptr_t) &dummy;
+  SEXP ans = PROTECT(RinitJVM_with_padding(par, padding, dummy));
+
+  if (val >= JSW_DETECT) {
+
+    void *newBound = findBound((void*)R_CStackStart, oldBound, -R_CStackDir);
+    if (oldBound == newBound) {
+      /* No guard pages inserted, keep the original stack size.
+         This includes the case when the original stack size was
+         unlimited. */
+      UNPROTECT(1); /* ans */
+      return ans;
+    }
+
+    intptr_t oldb = (intptr_t)oldBound;
+    intptr_t newb = (intptr_t)newBound;
+    intptr_t lim = ((intptr_t)R_CStackStart - newb) * R_CStackDir;
+    uintptr_t newlim = (uintptr_t) (lim * 0.95);
+
+    uintptr_t oldlim = R_CStackLimit;
+    if (val >= JSW_ADJUST)
+      R_CStackLimit = newlim;
+
+    /* Only report when the loss is big. There will always be some bytes
+       lost because even with the original setting of R_CStackLimit before
+       initializing the JVM, one cannot access all bytes of stack. */
+
+    int bigloss = 0;
+    if (oldlim == -1) {
+      /* the message may be confusing when R_CStackLimit was set to -1
+         because the original stack size was too large */
+      REprintf("Rjava.init.warning: stack size reduced from unlimited to"
+        " %u bytes after JVM initialization.\n", newlim);
+      bigloss = 1;
+    } else {
+      unsigned lost = (unsigned) (oldlim - newlim);
+      if (lost > oldlim * 0.01) {
+        REprintf("Rjava.init.warning: lost %u bytes of stack after JVM"
+          " initialization.\n", lost);
+        bigloss = 1;
+      }
+    }
+
+    if (bigloss) {
+      if (val >= JSW_PREVENT && padding == 0)
+        REprintf("Rjava.init.warning: re-try with increased"
+          " stack size via ulimit -s to allow for a work-around.\n");
+      if (val < JSW_ADJUST)
+        REprintf("Rjava.init.warning: R may crash in recursive calls.\n");
+    }
+  }
+
+  UNPROTECT(1); /* ans */
+  return ans;
+}
+
+#endif /* JVM_STACK_WORKAROUND */
+
+/** RinitJVM(classpath)
+    initializes JVM with the specified class path */
+REP SEXP RinitJVM(SEXP par) {
+
+#ifndef JVM_STACK_WORKAROUND
+  return RinitJVM_real(par);
+#else
+  return RinitJVM_jsw(par);
+#endif
 }
 
 REP void doneJVM() {


### PR DESCRIPTION
On Linux, Oracle JVM inserts guard pages into the C stack of the initial thread, which is the main R thread in case of rJava. The stack size is limited to 2M or the maximum size given by -Xss (or its default), whichever is smaller. R needs typically a bigger stack and, yet worse, it cannot detect stack overflow anymore after the guard pages have been inserted. This patch detects when the stack is reduced and updates R stack information accordingly so that R can still detect stack overflow. Moreover, the patch includes a workaround that prevents the JVM from significantly shrinking the stack if possible. A warning is printed if the stack has still been reduced considerably. This code is only compiled and used on Linux.