### PR TITLE
Expand NEWS entry for jvm stack truncation workaround on Linux.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,8 +16,16 @@
 
     o	Process events on Widnows while in rniIndle. (#23)
 
-    o	Add a work-around for a bug in Oracle Java on Linux which causes
-	segfaults due to stack truncation. (#102)
+    o	Work around a bug of Oracle's Java on Linux which caps the stack of
+	R at 2M. (#102) The bug leads to segfaults in recursive
+	computations (not an R error as R doesn't know the stack size has
+	been reduced).  The workaround can be disabled via environment
+	variable RJAVA_JVM_STACK_WORKAROUND=0, which may produce better
+	results with memory access checkers (ASAN, valgrind), because the
+	workaround detects the new stack size by trying to access
+	inaccessible memory.  This JVM behavior was a workaround for an
+	issue in old Linux systems (JDK-4466587) and is going to be fixed in
+	Java 10.
 
     o	Work around a change in registry location on Windows for Oracle
 	Java 1.9. (#120)


### PR DESCRIPTION
Expands the NEWS entry for the JVM stack workaround. Documents how to disable the workaround via environment variable, which is useful for memory access checkers. 