### PR TITLE
Removing the reference to the decommissioned mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,5 @@ since the checkout is not the acutal package.
 
 ### Mailing list and bug reports
 
-Please use
-[stats-rosuda-devel](https://mailman.rz.uni-augsburg.de/mailman/listinfo/stats-rosuda-devel)
-mailing list for questions about rJava and [rJava GitHub issues
-page](https://github.com/s-u/rJava/issues) to report bugs.
+Please use [rJava GitHub issues page](https://github.com/s-u/rJava/issues) to report bugs.
 


### PR DESCRIPTION
The referenced mailing list, https://mailman.rz.uni-augsburg.de/mailman/listinfo/stats-rosuda-devel
is not available anymore. Removing it from the README.md

I hated that I was only asking while contributing nothing to the project.