### PR TITLE
Namespace: export .need.init()

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -4,7 +4,7 @@ export( "%instanceof%" )
 
 export( clone )
 S3method( clone, default ) 
-export(is.jnull, .r2j, .rJava.base.path, toJava)
+export(is.jnull, .r2j, .rJava.base.path, toJava, .need.init)
 exportClasses(jobjRef, jarrayRef, jrectRef, jfloat, jlong, jbyte, jchar, jclassName)
 exportMethods(show, "$", "$<-", 
 	"==", "!=", "<", ">", "<=", ">=", 


### PR DESCRIPTION
Hello,

Would it be possible to export .need.init()? I need to be able to run it in order to check how much memory has been allocated to rJava, and to set that memory if java has not yet been initialized, but currently have to use `:::` to access the function.

My functions are https://github.com/ck37/ck37r/blob/master/R/get_java_memory.R#L21 and https://github.com/ck37/ck37r/blob/master/R/set_java_memory.R#L24 . I am working through my final CRAN notes in order to do an update.

Thanks,
Chris