### PR TITLE
fix HAVE_XRS detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -235,7 +235,7 @@ fi
 
 AC_MSG_CHECKING([whether -Xrs will be used])
 AC_MSG_RESULT(${has_xrs})
-if test "$has_xrs" = xyes; then
+if test x"$has_xrs" = xyes; then
    AC_DEFINE(HAVE_XRS, 1, [Set if the Java parameter -Xrs is supported])
 fi
 


### PR DESCRIPTION
It seems to me there was a typo in the detection of whether the parameter `-Xrs` should be used. Consequently `HAVE_XRS` was not written to `config.h` independent of whether one used the `--enable-xrs` configure option.