### PR TITLE
Support IBM JRE

### DIFF
--- a/R/windows/FirstLib.R
+++ b/R/windows/FirstLib.R
@@ -34,6 +34,7 @@ function(libname, pkgname) {
     paths <- c(paths,
                file.path(javahome, "bin", "client"), # 32-bit
                file.path(javahome, "bin", "server"), # 64-bit
+               file.path(javahome, "bin", "j9vm"), # IBM
                file.path(javahome, "bin"), # base (now needed for MSVCRT in recent Sun Java)
                file.path(javahome, "jre", "bin", "server"), # old 64-bit (or manual JAVA_HOME setting to JDK)
                file.path(javahome, "jre", "bin", "client")) # old 32-bit (or manual JAVA_HOME setting to JDK)

--- a/R/windows/FirstLib.R
+++ b/R/windows/FirstLib.R
@@ -37,7 +37,8 @@ function(libname, pkgname) {
                file.path(javahome, "bin", "j9vm"), # IBM
                file.path(javahome, "bin"), # base (now needed for MSVCRT in recent Sun Java)
                file.path(javahome, "jre", "bin", "server"), # old 64-bit (or manual JAVA_HOME setting to JDK)
-               file.path(javahome, "jre", "bin", "client")) # old 32-bit (or manual JAVA_HOME setting to JDK)
+               file.path(javahome, "jre", "bin", "client"), # old 32-bit (or manual JAVA_HOME setting to JDK)
+               file.path(javahome, "jre", "bin", "j9vm")) # IBM (JAVA_HOME set to JDK)
     cpc <- strsplit(curPath, ";", fixed=TRUE)[[1]] ## split it up so we can check presence/absence of a path
 
     ## add paths only if they are not in already and they exist


### PR DESCRIPTION
This PR adds support for IBM's JRE.

### Problem
* Oracle's JRE puts `jvm.dll` in `jre/bin/server` or `jre/bin/client`
* IBM's JRE puts `jvm.dll` in `jre/bin/j9vm`
* Users with IBM's JRE can't use rJava since it doesn't look for `jvm.dll` where IBM's JRE puts it

### Solution
* Add `jre/bin/j9vm` so rJava can find `jvm.dll` with IBM's JRE

Resolves #169.