### PR TITLE
fix a bunch of typos

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,7 +6,7 @@
 	if rJava class loader was not present yet (only affected
 	initialization).
 
-    o	modify boostrap to avoid reflection calls which are broken in
+    o	modify bootstrap to avoid reflection calls which are broken in
 	Java 12 (see #175 and https://bugs.openjdk.java.net/browse/JDK-8221530).
 
     o	added .jgc() to run JVM garbage collector (#180)
@@ -27,7 +27,7 @@
 
     o	Windows: detect JAVA_HOME correctly from registry even if the
 	key is using JDK instead Java Development Kit (#120)
-	
+
     o	Windows: don't fail if `RuntimeLib` registry entry is missing (#163)
 
 
@@ -54,7 +54,7 @@
 	so you can still build 1.2/1.4 targets by reverting 992828b and
 	using a JDK that won't break on 1.4 targets.
 
-    o	Process events on Widnows while in rniIndle. (#23)
+    o	Process events on Windows while in rniIndle. (#23)
 
     o	Work around a bug of Oracle's Java on Linux which caps the stack of
 	R at 2M. (#102) The bug leads to segfaults in recursive
@@ -116,17 +116,17 @@
     o	added support for unboxing of Double[], Integer[] and Boolean[]
 	to .jevalArray(.., simplify=TRUE) and thus also to .jcall()
 
-    o	Windows: add Java configuartion paths before existing PATH
+    o	Windows: add Java configuration paths before existing PATH
 	entries
 
     o	Windows: honor a new option "java.home" to override JAVA_HOME
 	environment variable and system settings to allow co-existence
-	of other tools that may require differen Java paths.
+	of other tools that may require different Java paths.
 
     o	Windows: fix a buglet in error reporting when no Java is installed
 
     o	raise an error if the number of arguments to a Java call exceeds
-	maxJavaPars. Previously, calls woud be silently truncated.
+	maxJavaPars. Previously, calls would be silently truncated.
 	Note that maxJavaPars can be raised by compiling rJava, e.g. with:
 	PKG_CFLAGS=-DmaxJavaPars=96 R CMD INSTAL rJava_...
 
@@ -153,16 +153,16 @@
 
 0.9-0	2011-06-22
     o	fixes issues introduced by several new features in the late
-	0.8 series. Most imporantly .jarray() and .jevalArray() behave
+	0.8 series. Most importantly .jarray() and .jevalArray() behave
 	as intended (and as implemented in previous versions). The
 	same applies to .jcall() behavior with respect to arrays and
-	its evalArray arument. The defaults for some new arguments
+	its evalArray argument. The defaults for some new arguments
 	have been changed to reflect the original behavior.
 
     o	.jevalArray() has an additional argument `simplify' which allows
 	multi-dimensional arrays to be converted to native R
 	types. Use with care - it may convert more recursive types in
-	the future so it should be used preferrably where you have
+	the future so it should be used preferably where you have
 	control over the types converted.
 
     o	fixed a bug in .jevalArray that was not simplifying string
@@ -180,7 +180,7 @@
         loader (not from additional jars)
 
 0.8-7	2010-10-18
-    o	Windows updates to accomodate changes in R 2.12 and layout
+    o	Windows updates to accommodate changes in R 2.12 and layout
 	changes in recent Sun Java installations.
 
 0.8-6	2010-09-17
@@ -196,7 +196,7 @@
     o	if the rJava class loader is used as a primary loader it will
 	also register as the context class loader. Some projects
 	rely on the thread context class loader instead of
-	Class.getClassLoader() [which is still more reliable] 
+	Class.getClassLoader() [which is still more reliable]
 	so those will now work as well.
 
     o	JRI 0.5-3 (bugfixes)
@@ -259,12 +259,12 @@
     o	new exception handling was introduced:
 
 	Java exceptions are mapped to Exception conditions which can
-	be used to catch the exception at R level using e.g tryCatch. 
-	
+	be used to catch the exception at R level using e.g tryCatch.
+
 	The class name automatically contains "Exception", "error"
 	and "condition", as well as all the names (without package path)
-	of the classes in the inheritance tree of the actual class of the 
-	Exception. This allows targetted handlers:
+	of the classes in the inheritance tree of the actual class of the
+	Exception. This allows targeted handlers:
 	tryCatch(.jnew("foo"), NoClassDefFoundError=function(e) ...)
 
 	In addition JNI code now causes an error instead of a warning,
@@ -285,71 +285,71 @@
 
 	An additional class "jclassName" was created to support static
 	calls to accessor methods such as $ and calls to new().
-	
+
     o   [RF] arrays are now split in two classes : "jrectRef" for rectangular
-        arrays, similar to R arrays, and jarrayRef for rugged arrays. 
-        Indexing of all arrays is supported using the double bracket 
+        arrays, similar to R arrays, and jarrayRef for rugged arrays.
+        Indexing of all arrays is supported using the double bracket
         indexer "[[" and "[[<-"
-        
-        The single indexer "[" is only currently implemented for 
-        rectangular arrays. This is experimental. Replacement ([<-) 
+
+        The single indexer "[" is only currently implemented for
+        rectangular arrays. This is experimental. Replacement ([<-)
         is not supported yet.
 
     o   [RF] with.jclassName and within.jclassName is added to support
-        "with" semantics on static fields and methods of java classes. 
-        
+        "with" semantics on static fields and methods of java classes.
+
         Double <- J("java.lang.Double" )
         with( Double, parseDouble( "10.2" ) )
-        
+
 
     o   [RF] length.jarrayRef queries the number
-        of objects in a java array. An exception is generated if the 
-        object is not an array. Also array$length can be used 
-        similary to array.length in java
-        
-    o   [RF] .jcast gains arguments "check" and "convert.array". Their 
-             default value is FALSE for backwards compatibility with 
+        of objects in a java array. An exception is generated if the
+        object is not an array. Also array$length can be used
+        similarly to array.length in java
+
+    o   [RF] .jcast gains arguments "check" and "convert.array". Their
+             default value is FALSE for backwards compatibility with
              previous releases of rJava
-             
-    o   [RF] Binary operators <, >, <=, >= to compare two objects where 
-             at least one is a java object reference. 
+
+    o   [RF] Binary operators <, >, <=, >= to compare two objects where
+             at least one is a java object reference.
              d <- new( J("java.lang.Double"), 0.0 )
              d < 1.0
              d < 1L
              Comparison of arrays is not currently supported
-             
+
     o   [RF] lapply and sapply may now be used on Iterable java objects
              such as Vector and java arrays. see ?as.list.jobjRef
-             
-    o   [RF] The generic "clone" function is added, and an implementation for 
-             java objects. an Object must implement the Cloneable 
-             interface, otherwise an exception will be raised. 
-             Furthermore, careful reading of the java documentation 
+
+    o   [RF] The generic "clone" function is added, and an implementation for
+             java objects. an Object must implement the Cloneable
+             interface, otherwise an exception will be raised.
+             Furthermore, careful reading of the java documentation
              of Object#clone is recommended since this is not standard
-             java behaviour. Currently "clone" is not supported on 
+             java behaviour. Currently "clone" is not supported on
              arrays
-             
-    o   [RF] A mechanism for "attach"ing java packages has been introduced, 
+
+    o   [RF] A mechanism for "attach"ing java packages has been introduced,
              following the mechanism of the RObjectTables package
              from the OmegaHat project. This allows to "attach" a set of
-             java package paths to R's search path: 
-             
+             java package paths to R's search path:
+
              > attach( javaImport( "java.util", "java.lang" ) )
-             
+
              and then use classes from this package like this :
-             
+
              > new( Vector )
              > new( HashMap )
              > new( Double, 10.2 )
-             > new( Integer, 10L ) 
+             > new( Integer, 10L )
              > Collections$EMPTY_MAP
-             
+
              This feature is currently __very__ experimental and is as
              dangerous as any other use of attach
 
 
 0.7-1	(never released)
-    o	[RF] added .J high-level java constructor (based on reflection 
+    o	[RF] added .J high-level java constructor (based on reflection
 	as opposed to complete match as .jnew does)
 
     o	[RF] added .jinstanceof and instanceof operator
@@ -397,7 +397,7 @@
     o	fix --enable-debug to really enable debug code
 
     o	improve Windows setup (add only paths if they are not already
-	listed and check thier presence first) and warn if the system
+	listed and check their presence first) and warn if the system
 	suffers from PATH truncation bug (or PATH is truncated in
 	general)
 
@@ -458,7 +458,7 @@
 
     o	Add support for short Java type
 
-    o	Add support for convertors
+    o	Add support for converters
 
     o	Fix R-devel compatibility issues
 
@@ -480,7 +480,7 @@
 
 0.4-13	2007-01-14
     o	Fix Java-side memory leaks (temporary parameters to methods
-	were not propery released, thanks to Erik van Barneveld for
+	were not properly released, thanks to Erik van Barneveld for
 	supplying a reproducible example).
 
     o	Fix a bug that caused only the first VM parameter to be passed
@@ -498,7 +498,7 @@
 
     o	Update URL to http://www.rforge.net/rJava/
 
-    o	Update to JRI 0.3-7 (LCons, createRJavaRef, assign XT_NONE) 
+    o	Update to JRI 0.3-7 (LCons, createRJavaRef, assign XT_NONE)
 
 0.4-12	2006-11-29
     o	Added documentation for .jthrow, .jclear and .jgetEx and
@@ -569,7 +569,7 @@
 	Also `show' is now used instead of `print' and the
 	output format was changed.
 
-    o	Protoype for jobjRef is now a valid null-Object
+    o	Prototype for jobjRef is now a valid null-Object
 
     o	Added .jequals and corresponding ==, != op methods.
 	Currently == and != operators feature the same behavior as

--- a/jri/Rengine.java
+++ b/jri/Rengine.java
@@ -2,18 +2,18 @@ package org.rosuda.JRI;
 
 import java.lang.*;
 
-/** Rengine class is the interface between an instance of R and the Java VM. Due to the fact that R has no threading support, you can run only one instance of R withing a multi-threaded application. There are two ways to use R from Java: individual call and full event loop. See the Rengine {@link #Rengine constructor} for details. <p> <u>Important note:</u> All methods starting with <code>rni</code> (R Native Interface) are low-level native methods that should be avoided if a high-level methods exists. They do NOT attempt any synchronization, so it is the duty of the calling program to ensure that the invocation is safe (see {@link #getRsync()} for details). At some point in the future when the high-level API is complete they should become private. However, currently this high-level layer is not complete, so they are available for now.<p>All <code>rni</code> methods use <code>long</code> type to reference <code>SEXP</code>s on R side. Those reference should never be modified or used in arithmetics - the only reason for not using an extra interface class to wrap those references is that <code>rni</code> methods are all <i>native</i> methods and therefore it would be too expensive to handle the unwrapping on the C side.<p><code>jri</code> methods are called internally by R and invoke the corresponding method from the even loop handler. Those methods should usualy not be called directly.
+/** Rengine class is the interface between an instance of R and the Java VM. Due to the fact that R has no threading support, you can run only one instance of R withing a multi-threaded application. There are two ways to use R from Java: individual call and full event loop. See the Rengine {@link #Rengine constructor} for details. <p> <u>Important note:</u> All methods starting with <code>rni</code> (R Native Interface) are low-level native methods that should be avoided if a high-level methods exists. They do NOT attempt any synchronization, so it is the duty of the calling program to ensure that the invocation is safe (see {@link #getRsync()} for details). At some point in the future when the high-level API is complete they should become private. However, currently this high-level layer is not complete, so they are available for now.<p>All <code>rni</code> methods use <code>long</code> type to reference <code>SEXP</code>s on R side. Those reference should never be modified or used in arithmetics - the only reason for not using an extra interface class to wrap those references is that <code>rni</code> methods are all <i>native</i> methods and therefore it would be too expensive to handle the unwrapping on the C side.<p><code>jri</code> methods are called internally by R and invoke the corresponding method from the even loop handler. Those methods should usually not be called directly.
 
- <p>Since 0.5 a failure to load the JRI naitve library will not be fatal if <code>jri.ignore.ule=yes</code> system preference is set. Rengine will still not work, but that gives a chance to GUI programs to report the error in a more meaningful way (use {@link #jriLoaded} to check the availability of JRI). 
+ <p>Since 0.5 a failure to load the JRI naitve library will not be fatal if <code>jri.ignore.ule=yes</code> system preference is set. Rengine will still not work, but that gives a chance to GUI programs to report the error in a more meaningful way (use {@link #jriLoaded} to check the availability of JRI).
  */
 public class Rengine extends Thread {
-	/** this flags is set to <code>true</code> if the native code was successfully loaded. If this flag is <code>false</code> then none of the rni methods are available. Previous 
+	/** this flags is set to <code>true</code> if the native code was successfully loaded. If this flag is <code>false</code> then none of the rni methods are available. Previous
 	 @since API 1.9, JRI 0.5
 	 */
 	public static boolean jriLoaded;
 
     boolean loopHasLock = false;
-    
+
     static {
         try {
             System.loadLibrary("jri");
@@ -60,18 +60,18 @@ public class Rengine extends Thread {
 	public static boolean versionCheck() {
 		return (getVersion()==rniGetVersion());
 	}
-	
+
     /** debug flag. Set to value &gt;0 to enable debugging messages. The verbosity increases with increasing number */
     public static int DEBUG = 0;
-	
+
 	/** this value specifies the time (in ms) to spend sleeping between checks for R shutdown requests if R event loop is not used. The default is 200ms. Higher values lower the CPU usage but may make R less responsive to shutdown attempts (in theory it should not matter because {@link #stop()} uses interrupt to awake from the idle sleep immediately, but some implementation may not honor that).
 	@since JRI 0.3
 	*/
 	public int idleDelay = 200;
-	
+
     /** main engine. Since there can be only one instance of R, this is also the only instance. */
     static Rengine mainEngine=null;
-    
+
     /** return the current main R engine instance. Since there can be only one true R instance at a time, this is also the only instance. This may not be true for future versions, though.
 	@return current instance of the R engine or <code>null</code> if no R engine was started yet. */
     public static Rengine getMainEngine() { return mainEngine; }
@@ -99,8 +99,8 @@ public class Rengine extends Thread {
 	Mutex Rsync;
 	/** callback handler */
     RMainLoopCallbacks callback;
-	
-    /** create and start a new instance of R. 
+
+    /** create and start a new instance of R.
 	@param args arguments to be passed to R. Please note that R requires the presence of certain arguments (e.g. <code>--save</code> or <code>--no-save</code> or equivalents), so passing an empty list usually doesn't work.
 	@param runMainLoop if set to <code>true</code> the the event loop will be started as soon as possible, otherwise no event loop is started. Running loop requires <code>initialCallbacks</code> to be set correspondingly as well.
 	@param initialCallbacks an instance implementing the {@link org.rosuda.JRI.RMainLoopCallbacks RMainLoopCallbacks} interface that provides methods to be called by R
@@ -143,7 +143,7 @@ public class Rengine extends Thread {
 	@return result code
      */
     native int rniSetupR(String[] args);
-    
+
     /** RNI: setup IPC with RJava. This method is used by rJava to pass the IPC information to the JRI engine for synchronization
 	@since experimental, not in the public API!
      */
@@ -159,7 +159,7 @@ public class Rengine extends Thread {
     synchronized int setupR() {
         return setupR(null);
     }
-    
+
     synchronized int setupR(String[] args) {
         int r=rniSetupR(args);
         if (r==0) {
@@ -169,7 +169,7 @@ public class Rengine extends Thread {
         }
         return r;
     }
-    
+
     /** RNI: parses a string into R expressions (do NOT use directly unless you know exactly what you're doing, where possible use {@link #eval} instead). Note that no synchronization is performed!
 	@param s string to parse
 	@param parts number of expressions contained in the string
@@ -256,7 +256,7 @@ public class Rengine extends Thread {
 	@param exps initial contents of the vector consisiting of an array of references
 	@return reference to the resulting VECSXP */
     public synchronized native long rniPutVector(long[] exps);
-    
+
     /** RNI: get an attribute
 	@param exp reference to the object whose attribute is requested
 	@param name name of the attribute
@@ -264,9 +264,9 @@ public class Rengine extends Thread {
     public synchronized native long rniGetAttr(long exp, String name);
 	/** RNI: get attribute names
 	 @param exp reference to the object whose attributes are requested
-	 @return a list of strings naming all attributes or <code>null</code> if there are none 
+	 @return a list of strings naming all attributes or <code>null</code> if there are none
 	 @since API 1.9, JRI 0.5 */
-    public synchronized native String[] rniGetAttrNames(long exp);	
+    public synchronized native String[] rniGetAttrNames(long exp);
     /** RNI: set an attribute
 	 @param exp reference to the object whose attribute is to be modified
 	 @param name attribute name
@@ -277,7 +277,7 @@ public class Rengine extends Thread {
 		@since API 1.5, JRI 0.3
 		@param exp reference to an object
 		@param cName name of the class to check
-		@return <code>true</code> if <code>cName</code> inherits from class <code>cName</code> (see <code>inherits</code> in R) */ 
+		@return <code>true</code> if <code>cName</code> inherits from class <code>cName</code> (see <code>inherits</code> in R) */
 	public synchronized native boolean rniInherits(long exp, String cName);
 
     /** RNI: create a dotted-pair list (LISTSXP or LANGSXP)
@@ -355,7 +355,7 @@ public class Rengine extends Thread {
 		@since API 1.9, JRI 0.5
 		@param exp reference to an R object */
 	public synchronized native void rniRelease(long exp);
-	
+
 	/** RNI: return the parent environment
 		@since API 1.9, JRI 0.5
 		@param exp reference to environment
@@ -381,7 +381,7 @@ public class Rengine extends Thread {
 		@param which constant referring to a particular special object (see SO_xxx constants)
 		@return reference to a special object or 0 if the kind of object it unknown/unsupported */
 	public synchronized native long rniSpecialObject(int which);
-	
+
 	//--- was API 1.4 but it only caused portability problems, so we got rid of it
     //public static native void rniSetEnv(String key, String val);
     //public static native String rniGetEnv(String key);
@@ -399,16 +399,16 @@ public class Rengine extends Thread {
 		@since API 1.5, JRI 0.3
 		*/
 	public synchronized native Object rniXrefToJava(long exp);
-	
+
     /** RNI: return the API version of the native library
 		@return API version of the native library */
     public static native long rniGetVersion();
-    
+
     /** RNI: interrupt the R process (if possible). Note that R handles interrupt requests in (R-thread-)synchronous, co-operative fashion as it wants to make sure that the interrupted state is recoverable. If interrupting from another thread while using blocking ReadConsole REPL make sure you also interrupt your ReadConsole call after rniStop such that R can act on the signalled interrupt.
 	@param flag determines how to attempt to inform R about the interrput. For normal (safe) operation using flag signalling must be 0. Other options are 1 (SIGINT for compatibility with older JRI API) and 2 (<tt>Rf_onintr</tT> call - use <u>only</u> on the R thread and only if you know what it means). Values other than 0 are only supported since JRI 0.5-4.
 	@return result code (currently 0) */
     public native int rniStop(int flag);
-    
+
     /** RNI: assign a value to an environment
 	@param name name
 	@param exp value
@@ -417,14 +417,14 @@ public class Rengine extends Thread {
         @since API 1.10, JRI 0.5-1 (existed before but returned <code>void</code>)
     */
     public synchronized native boolean rniAssign(String name, long exp, long rho);
-    
+
     /** RNI: get the SEXP type
 	@param exp reference to a SEXP
 	@return type of the expression (see xxxSEXP constants) */
     public synchronized native int rniExpType(long exp);
     /** RNI: run the main loop.<br> <i>Note:</i> this is an internal method and it doesn't return until the loop exits. Don't use directly! */
     public native void rniRunMainLoop();
-    
+
     /** RNI: run other event handlers in R */
     public synchronized native void rniIdle();
 
@@ -439,7 +439,7 @@ public class Rengine extends Thread {
     public void startMainLoop() {
 		runLoop=true;
     }
-    
+
     //============ R callback methods =========
 
     /** JRI: R_WriteConsole call-back from R
@@ -486,7 +486,7 @@ public class Rengine extends Thread {
     {
         if (callback!=null) callback.rShowMessage(this, message);
     }
-    
+
     /** JRI: R_loadhistory call-back from R
 	@param filename name of the history file */
     public void jriLoadHistory(String filename)
@@ -500,7 +500,7 @@ public class Rengine extends Thread {
     {
         if (callback!=null) callback.rSaveHistory(this, filename);
     }
-	
+
     /** JRI: R_ChooseFile call-back from R
 	@param newFile flag specifying whether an existing or new file is requested
 	@return name of the selected file or <code>null</code> if cancelled */
@@ -509,14 +509,14 @@ public class Rengine extends Thread {
         if (callback!=null) return callback.rChooseFile(this, newFile);
 		return null;
     }
-	
-    /** JRI: R_FlushConsole call-back from R */	
+
+    /** JRI: R_FlushConsole call-back from R */
     public void jriFlushConsole()
     {
         if (callback!=null) callback.rFlushConsole(this);
     }
-	
-    
+
+
     //============ "official" API =============
 
 
@@ -526,7 +526,7 @@ public class Rengine extends Thread {
     public synchronized REXP eval(String s) {
 		return eval(s, true);
 	}
-	
+
     /** Parses and evaluates an R expression and returns the result.
 		@since JRI 0.3
 		@param s expression (as string) to parse and evaluate
@@ -559,7 +559,7 @@ public class Rengine extends Thread {
         if (DEBUG>0) System.out.println("Rengine.eval("+s+"): END (ERR)"+Thread.currentThread());
         return null;
     }
-    
+
     /** This method is very much like {@link #eval(String)}, except that it is non-blocking and returns <code>null</code> if the engine is busy.
         @param s string to evaluate
         @return result of the evaluation or <code>null</code> if the engine is busy
@@ -592,7 +592,7 @@ public class Rengine extends Thread {
         }
         return null;
     }
-    
+
 	/** returns the synchronization mutex for this engine. If an external code needs to use RNI calls, it should do so only in properly protected environment secured by this mutex. Usually the procedure should be as follows:<pre>
 	boolean obtainedLock = e.getRsync().safeLock();
 	try {
@@ -607,7 +607,7 @@ public class Rengine extends Thread {
 	public Mutex getRsync() {
 		return Rsync;
 	}
-	
+
     /** check the state of R
 		@return <code>true</code> if R is alive and <code>false</code> if R died or exitted */
     public synchronized boolean waitForR() {
@@ -619,21 +619,21 @@ public class Rengine extends Thread {
         alive = false;
         interrupt();
     }
-    
-    /** The implementation of the R thread. This method should not be called directly. */	
+
+    /** The implementation of the R thread. This method should not be called directly. */
     public void run() {
 	if (DEBUG > 0)
 	    System.out.println("Starting R...");
 	loopHasLock = Rsync.safeLock(); // force all code to wait until R is ready
 	try {
 	    if (setupR(args) == 0) {
-		if (!runLoop && loopHasLock) { // without event loop we can unlock now since we woin't do anything
+		if (!runLoop && loopHasLock) { // without event loop we can unlock now since we won't do anything
 		    Rsync.unlock();
 		    loopHasLock = false;
 		}
 		while (alive) {
 		    try {
-			if (runLoop) {                        
+			if (runLoop) {
 			    if (DEBUG > 0)
 				System.out.println("***> launching main loop:");
 			    loopRunning = true;
@@ -662,7 +662,7 @@ public class Rengine extends Thread {
 	    if (loopHasLock) Rsync.unlock();
 	}
     }
-	
+
 	/** assign a string value to a symbol in R. The symbol is created if it doesn't exist already.
          *  @param sym symbol name.  The symbol name is used as-is, i.e. as if it was quoted in R code (for example assigning to "foo$bar" has the same effect as `foo$bar`&lt;- and NOT foo$bar&lt;-).
 	 *  @param ct contents

--- a/jri/configure
+++ b/jri/configure
@@ -3249,7 +3249,7 @@ fi
 
 
 if test -n "${CONFIGURED}"; then
-## re-map varibles that don't match
+## re-map variables that don't match
 JAVA_PROG="${JAVA}"
 JAVA_INC="${JAVA_CPPFLAGS}"
 JAVA_LD_PATH="${JAVA_LD_LIBRARY_PATH}"
@@ -5234,4 +5234,3 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
-

--- a/jri/configure.ac
+++ b/jri/configure.ac
@@ -85,7 +85,7 @@ AC_DEFUN([RUN_JAVA],
 ])
 
 if test -n "${CONFIGURED}"; then
-## re-map varibles that don't match
+## re-map variables that don't match
 JAVA_PROG="${JAVA}"
 JAVA_INC="${JAVA_CPPFLAGS}"
 JAVA_LD_PATH="${JAVA_LD_LIBRARY_PATH}"
@@ -186,7 +186,7 @@ if test -n "${JAVA_PROG}" ; then
 fi
 
 if test "x`uname -s 2>/dev/null`" = xDarwin; then
-  ## we need to pull that out of R in case re-export fails (which is does on 10.11)                                                                  
+  ## we need to pull that out of R in case re-export fails (which is does on 10.11)
   DYLD_FALLBACK_LIBRARY_PATH=`"${RBIN}" --slave --vanilla -e 'cat(Sys.getenv("DYLD_FALLBACK_LIBRARY_PATH"))'`
   export DYLD_FALLBACK_LIBRARY_PATH
 fi
@@ -198,7 +198,7 @@ if test ${acx_java_works} = yes; then
   AC_MSG_RESULT([yes])
 
   AC_MSG_CHECKING([for Java environment])
-  ## retrieve JAVA_HOME from Java itself if not set 
+  ## retrieve JAVA_HOME from Java itself if not set
   if test -z "${JAVA_HOME}" ; then
     RUN_JAVA(JAVA_HOME,[-classpath ${getsp_cp} getsp java.home])
   fi

--- a/man/accessOp.Rd
+++ b/man/accessOp.Rd
@@ -41,14 +41,14 @@
 	 }
 }
 \details{
-  rJava provies two levels of API: low-level JNI-API in the form of \code{\link{.jcall}} function and high-level reflection API based on the \code{$} operator. The former is very fast, but inflexible. The latter is a convenient way to use Java-like programming at the cost of performance. The reflection API is build around the \code{$} operator on \code{\link{jobjRef-class}} objects that allows to access Java attributes and call object methods.
+  rJava provides two levels of API: low-level JNI-API in the form of \code{\link{.jcall}} function and high-level reflection API based on the \code{$} operator. The former is very fast, but inflexible. The latter is a convenient way to use Java-like programming at the cost of performance. The reflection API is build around the \code{$} operator on \code{\link{jobjRef-class}} objects that allows to access Java attributes and call object methods.
 
  \code{$} returns either the value of the attribute or calls a method, depending on which name matches first.
 
  \code{$<-} assigns a value to the corresponding Java attribute.
 
- \code{names} and \code{.DollarNames} returns all fields and methods associated with the object. 
- Method names are followed by \code{(} or \code{()} depending on arity. 
+ \code{names} and \code{.DollarNames} returns all fields and methods associated with the object.
+ Method names are followed by \code{(} or \code{()} depending on arity.
  This use of names is mainly useful for code completion, it is not intended to be used programmatically.
 
  This is just a convenience API. Internally all calls are mapped into \code{\link{.jcall}} calls, therefore the calling conventions and returning objects use the same rules. For time-critical Java calls \code{\link{.jcall}} should be used directly.
@@ -66,7 +66,7 @@ names(v)
 
 \dontshow{
 stopifnot( v$length() == 12L )
-stopifnot( v$indexOf("World") == 6L ) 
+stopifnot( v$indexOf("World") == 6L )
 }
 
 J("java.lang.String")$valueOf(10)
@@ -74,7 +74,7 @@ J("java.lang.String")$valueOf(10)
 Double <- J("java.lang.Double")
 # the class pseudo field - instance of Class for the associated class
 # similar to java Double.class
-Double$class 
+Double$class
 \dontshow{
 	stopifnot( Double$class$getName() == "java.lang.Double" )
 }

--- a/man/jarray.Rd
+++ b/man/jarray.Rd
@@ -21,16 +21,16 @@
   \item{contents.class}{common class of the contained objects, see
     details}
   \item{obj}{Java object reference to an array that is to be evaluated}
-  \item{rawJNIRefSignature}{JNI signature that whould be used for
+  \item{rawJNIRefSignature}{JNI signature that would be used for
     conversion. If set to \code{NULL}, the signature is detected
     automatically.}
   \item{silent}{if set to true, warnings are suppressed}
-  \item{dispatch}{logical. If \code{TRUE} the code attemps to dispatch
+  \item{dispatch}{logical. If \code{TRUE} the code attempts to dispatch
   to either a \code{jarrayRef} object for rugged arrays and
   \code{jrectRef} objects for rectangular arrays, creating possibly a
   multi-dimensional object in Java (e.g., when used with a matrix).}
   \item{simplify}{if set to \code{TRUE} more than two-dimensional arrays
-  are converted to native obejcts (e.g., matrices) if their type and
+  are converted to native objects (e.g., matrices) if their type and
   size matches (essentially the inverse for objects created with
   \code{dispatch=TRUE}).}
 }
@@ -68,7 +68,7 @@
   \code{.jevalArray} currently supports only a subset of all possible
   array types. Recursive arrays are handled by returning a list of
   references which can then be evaluated separately. The only exception
-  is \code{simplify=TRUE} in which case \code{.jevalArray} arrempts to
+  is \code{simplify=TRUE} in which case \code{.jevalArray} attempts to
   convert multi-dimensional arrays into native R type if there is a
   such. This only works for rectangular arrays of the same basic type
   (i.e. the length and type of each referenced array is the same -

--- a/man/jcall.Rd
+++ b/man/jcall.Rd
@@ -7,8 +7,8 @@
   \code{.jcall} calls a Java method with the supplied arguments.
 }
 \usage{
-.jcall(obj, returnSig = "V", method, ..., evalArray = TRUE, 
-    evalString = TRUE, check = TRUE, interface = "RcallMethod", 
+.jcall(obj, returnSig = "V", method, ..., evalArray = TRUE,
+    evalString = TRUE, check = TRUE, interface = "RcallMethod",
     simplify = FALSE, use.true.class = FALSE)
 }
 \arguments{
@@ -22,7 +22,7 @@
     type \code{short}.}
   \item{method}{The name of the method to be called}
   \item{...}{
-    Any parametes that will be passed to the Java method. The parameter
+    Any parameters that will be passed to the Java method. The parameter
     types are determined automatically and/or taken from the
     \code{jobjRef} object. All named parameters are discarded.}
   \item{evalArray}{This flag determines whether the array return value
@@ -35,22 +35,22 @@
   \item{check}{If set to \code{TRUE} then checks for exceptions are
     performed before and after the call using
     \code{\link{.jcheck}(silent=FALSE)}. This is usually the desired
-    behavior, because all calls fail until an expection is cleared.}
+    behavior, because all calls fail until an exception is cleared.}
   \item{interface}{This option is experimental and specifies the
     interface used for calling the Java method; the current
     implementation supports two interfaces:
     \itemize{
       \item{\code{"RcallMethod"}}{the default interface.}
       \item{\code{"RcallSyncMethod"}}{synchronized call of a
-	method. This has simmilar effect as using \code{synchronize} in
+	method. This has similar effect as using \code{synchronize} in
 	Java.}
     }
   }
   \item{use.true.class}{logical. If set to \code{TRUE}, the true class
-  of the returned object will be used instead of the declared signature. 
-  \code{TRUE} allows for example to grab the actual class of an object when 
-  the return type is an interface, or allows to grab an array when the 
-  declared type is Object and the returned object is an array. Use \code{FALSE} 
+  of the returned object will be used instead of the declared signature.
+  \code{TRUE} allows for example to grab the actual class of an object when
+  the return type is an interface, or allows to grab an array when the
+  declared type is Object and the returned object is an array. Use \code{FALSE}
   for efficiency when you are sure about the return type. }
 }
 \value{
@@ -88,7 +88,7 @@
   memory usage), but 3rd party code may not (e.g. older
   packages). Also rJava relies on correct encoding flags for strings
   passed to it and will attempt to perform conversions where
-  necessary. If some 3rd party code produces strings incorreclty
+  necessary. If some 3rd party code produces strings incorrectly
   flagged, all bets are off.
 
   Finally, for performance reasons class, method and field names as

--- a/man/jcastToArray.Rd
+++ b/man/jcastToArray.Rd
@@ -29,17 +29,17 @@
 }
 \details{
   Sometimes a result of a method is by definition of the class
-  \code{java.lang.Object}, but the acutal referenced object may be an
+  \code{java.lang.Object}, but the actual referenced object may be an
   array. In that case the method returns a Java object reference instead
   of an array reference. In order to obtain an array reference, it is
   necessary to cast such an object to an array reference - this is done
   using the above \code{.jcastToArray} function.
 
-  The input is an object reference that points to an array. Ususally the
+  The input is an object reference that points to an array. Usually the
   signature should be left at \code{NULL} such that it is determined
   from the object's class. This is also a check, because if the object's
   class is not an array, then the functions fails either with an error
-  (when \code{quiet=FALSE}) or by returing the original object (when
+  (when \code{quiet=FALSE}) or by returning the original object (when
   \code{quiet=TRUE}). If the signature is set to anything else, it is
   not verified and the array reference is always created, even if it may
   be invalid and unusable.

--- a/man/jcheck.Rd
+++ b/man/jcheck.Rd
@@ -12,7 +12,7 @@
 
   \code{.jthrow} throws a Java exception.
 
-  \code{.jgetEx} polls for any pending expections and returns the exception object.
+  \code{.jgetEx} polls for any pending exceptions and returns the exception object.
 
   \code{.jclear} clears a pending exception.
 }
@@ -29,7 +29,7 @@
     \code{stderr} so it will not appear there (as of rJava 0.5-1 some
     errors that the JVM prints using the vfprintf callback are passed
     to R. However, some parts are printed using \code{System.err} in
-    which case the ususal redirection using the \code{System} class
+    which case the usual redirection using the \code{System} class
     can be used by the user).}
   \item{exception}{is either a class name of an exception to create or a
     throwable object reference that is to be thrown.}
@@ -54,9 +54,9 @@
   instructed to not do so. If you want to handle Java exceptions, you
   should make sure that those function don't clear the exception you may
   want to catch.
-  
+
   The exception handling is still as a very low-level and experimental,
-  because it requires polling of exceptions. A more elaboate system
+  because it requires polling of exceptions. A more elaborate system
   using constructs similar to \code{try} ... \code{catch} is planned for
   next major version of \code{rJava}.
 

--- a/man/jfield.Rd
+++ b/man/jfield.Rd
@@ -2,7 +2,7 @@
 \alias{.jfield}
 \alias{.jfield<-}
 \title{
-  Obtains the value of a field 
+  Obtains the value of a field
 }
 \description{
   \code{.jfield} returns the value of the specified field on an object.
@@ -21,7 +21,7 @@
     the reflection lookup is quite expensive.}
   \item{name}{name of the field to access}
   \item{true.class}{by default the class of the resulting object matches
-    the siganture of the field. Setting this flag to \code{TRUE} causes
+    the signature of the field. Setting this flag to \code{TRUE} causes
     \code{.jfield} to use true class name of the resulting object
     instead. (this flag has no effect on scalar fields)}
   \item{convert}{when set to \code{TRUE} all references are converted to

--- a/man/jfloat.Rd
+++ b/man/jfloat.Rd
@@ -47,10 +47,10 @@
   has no native type that will hold a \code{long} value, so conversion
   between Java's \code{long} type and R's numeric is potentially lossy.
 
-  \code{.jbyte} is used when a scalar byte is to be passed ot Java. Note
+  \code{.jbyte} is used when a scalar byte is to be passed to Java. Note
   that byte arrays are natively passed as RAW vectors, not as
   \code{.jbyte} arrays.
-  
+
   \code{jchar} is strictly experimental and may be based on
   \code{character} vectors in the future.
 }

--- a/man/jmemprof.Rd
+++ b/man/jmemprof.Rd
@@ -26,14 +26,14 @@
 
   Note that lots of finalizers are run only when R exists, so usually
   you want to enable profiling early and let R exit to get a sensible
-  profile. Runninng gc may be helpful to get rid of references that can
+  profile. Running gc may be helpful to get rid of references that can
   be collected in R.
 
   A simple perl script is provided to analyze the result of the
   profiler. Due to its simple text format, it is possible to capture
   entire stdout including the profiler information to have both the
   console context for the allocations and the profile. Memory profiling
-  is also helful if rJava debug is enabled.
+  is also helpful if rJava debug is enabled.
 
   Note that memory profiling support must be compiled in rJava and it is
   by default compiled only if debug mode is enabled (which is not the

--- a/man/jnull.Rd
+++ b/man/jnull.Rd
@@ -28,7 +28,7 @@ is.jnull(x)
   \code{TRUE} or if \code{x} is a Java \code{null} reference.
 }
 \details{
-  \code{.jnull} is necesary if \code{null} is to be passed as an
+  \code{.jnull} is necessary if \code{null} is to be passed as an
   argument of \code{\link{.jcall}} or \code{\link{.jnew}}, in order to be
   able to find the correct method/constructor.
 

--- a/man/jrectRef-class.Rd
+++ b/man/jrectRef-class.Rd
@@ -17,11 +17,11 @@
 \alias{range,jrectRef-method}
 
 \title{Rectangular java arrays}
-\description{References to java arrays that are guaranteed to be rectangular, i.e similar 
+\description{References to java arrays that are guaranteed to be rectangular, i.e similar
 to R arrays}
 \section{Objects from the Class}{
-Objects of this class should *not* be created directly. 
-Instead, they usually come as a result of a java method call. 
+Objects of this class should *not* be created directly.
+Instead, they usually come as a result of a java method call.
 }
 \section{Slots}{
   \describe{
@@ -37,10 +37,10 @@ Class \code{"\linkS4class{jobjRef}"}, by class "jarrayRef", distance 2.
 }
 \section{Methods}{
   \describe{
-    \item{length}{\code{signature(x = "jrectRef")}: The number of elements in the array. 
-    	Note that if the array has more than one dimension, 
-    	it gives the number of arrays in the first dimension, and not the total 
-    	number of atomic objects in tha array (like R does). This gives what would be 
+    \item{length}{\code{signature(x = "jrectRef")}: The number of elements in the array.
+    	Note that if the array has more than one dimension,
+    	it gives the number of arrays in the first dimension, and not the total
+    	number of atomic objects in the array (like R does). This gives what would be 
 		returned by \code{array.length} in java.}
     \item{str}{\code{signature(object = "jrectRef")}: ... }
     \item{[}{\code{signature(x = "jrectRef")}: R indexing of rectangular java arrays }
@@ -71,7 +71,7 @@ array[ c(TRUE,FALSE,TRUE) ]
 array[ 1:2 ]
 array[ -3 ]
 
-# length 
+# length
 length( array )
 \dontshow{stopifnot(length(array) == 3L)}
 
@@ -95,7 +95,7 @@ x <- .jcall( "RectangularArrayExamples", "[[I",
 stopifnot( identical( typeof( x ), "integer" ) )
 stopifnot( identical( dim(x) , dim2d ) )
 stopifnot( identical( as.vector(x), 0:9 ) )
- 
+
 x <- .jcall( "RectangularArrayExamples", "[[B",
 "getByteDoubleRectangularArrayExample",  evalArray = TRUE, simplify = TRUE )
 stopifnot( identical( typeof( x ), "raw" ) )
@@ -141,7 +141,7 @@ stopifnot( identical( as.vector(x), as.character(0:9) ) )
 
 # 3d
 
-dim3d <- c(5L, 3L, 2L) 
+dim3d <- c(5L, 3L, 2L)
 
 x <- .jcall( "RectangularArrayExamples", "[[[Z",
 "getBooleanTripleRectangularArrayExample",  evalArray = TRUE, simplify = TRUE)
@@ -154,7 +154,7 @@ x <- .jcall( "RectangularArrayExamples", "[[[I",
 stopifnot( identical( typeof( x ), "integer" ) )
 stopifnot( identical( dim(x) , dim3d ) )
 stopifnot( identical( as.vector(x), 0:29 ) )
- 
+
 x <- .jcall( "RectangularArrayExamples", "[[[B",
 "getByteTripleRectangularArrayExample",  evalArray = TRUE, simplify = TRUE )
 stopifnot( identical( typeof( x ), "raw" ) )
@@ -196,7 +196,7 @@ x <- .jcall( "RectangularArrayExamples", "[[[Ljava/lang/String;",
 stopifnot( identical( typeof( x ), "character" ) )
 stopifnot( identical( dim(x) , dim3d ) )
 stopifnot( identical( as.vector(x), as.character(0:29) ) )
-          
+
 
 # testing the indexing
 
@@ -247,7 +247,7 @@ stopifnot( dim(xu) == 2L )
 # test duplicated
 x <- .jarray( rep( 1:2, each = 5 ), dispatch = TRUE )
 xd <- duplicated( x )
-stopifnot( xd == rep( c( FALSE, TRUE, TRUE, TRUE, TRUE), 2L ) ) 
+stopifnot( xd == rep( c( FALSE, TRUE, TRUE, TRUE, TRUE), 2L ) )
 if (rJava:::.base.has.anyDuplicated) stopifnot( anyDuplicated( x ) == 2L )
 
   p1 <- .jnew( "java/awt/Point" )

--- a/man/jreflection.Rd
+++ b/man/jreflection.Rd
@@ -10,7 +10,7 @@
   a given class or object.
   \code{.jmethods} returns a character vector with all methods for
   a given class or object.
-  \code{.jfields} returns a character vector with all fileds (aka attributes) for a given class or object.
+  \code{.jfields} returns a character vector with all fields (aka attributes) for a given class or object.
 }
 \usage{
 .jconstructors(o, as.obj = FALSE)

--- a/man/jserialize.Rd
+++ b/man/jserialize.Rd
@@ -84,7 +84,7 @@
   hold a reference to a Java object in R that is also referenced by
   the serialized Java object on the Java side, then this relationship
   cannot be retained upon restore. Instead, two copies of disjoint
-  objects will be created which can cause confusion and errorneous
+  objects will be created which can cause confusion and erroneous
   behavior.
 
   The cache is attached to the reference external pointer and thus it

--- a/man/loader.Rd
+++ b/man/loader.Rd
@@ -8,7 +8,7 @@
   \code{.jaddClassPath} adds directories or JAR files to the class
   path.
 
-  \code{.jclassPath} returns a vector containg the current entries in
+  \code{.jclassPath} returns a vector containing the current entries in
   the class path
 }
 \usage{
@@ -23,7 +23,7 @@
   \code{.jclassPath} returns a character vector listing the class path sequence.
 }
 %\details{
-% 
+%
 %}
 %\seealso{
 %  \code{\link{.jpackage}}

--- a/man/toJava.Rd
+++ b/man/toJava.Rd
@@ -5,7 +5,7 @@ Convert R objects to REXP references in Java
 }
 \description{
 \code{toJava} takes an R object and creates a reference to that object
-in Java. This reference can then be passed to Java methods such taht
+in Java. This reference can then be passed to Java methods such that
 they can refer to it back in R. This is commonly used to pass functions
 to Java such that Java code can call those functions later.
 }

--- a/src/Rglue.c
+++ b/src/Rglue.c
@@ -7,7 +7,7 @@
 
 #include <stdarg.h>
 
-/* max supported # of parameters to Java methdos */
+/* max supported # of parameters to Java methods */
 #ifndef maxJavaPars
 #define maxJavaPars 32
 #endif
@@ -26,7 +26,7 @@ REPC SEXP RJava_has_jri_cb() {
   LOGICAL(r)[0] = 0;
 #endif
   return r;
-} 
+}
 
 /* debugging output (enable with -DRJ_DEBUG) */
 #ifdef RJ_DEBUG
@@ -115,7 +115,7 @@ SEXP j2SEXP(JNIEnv *env, jobject o, int releaseLocal) {
       releaseObject(env, o);
     o=go;
   }
-  
+
   {
     SEXP xp = R_MakeExternalPtr(o, R_NilValue, R_NilValue);
 
@@ -147,7 +147,7 @@ const char *rj_char_utf8(SEXP s) {
 #endif
 
 HIDE void deserializeSEXP(SEXP o) {
-  _dbg(rjprintf("attempt to deserialize %p (clCL=%p, oCL=%p)\n", o, clClassLoader, oClassLoader));
+  _dbg(rjprintf("attempt to deserialize %p (clCl=%p, oCL=%p)\n", o, clClassLoader, oClassLoader));
   SEXP s = EXTPTR_PROT(o);
   if (TYPEOF(s) == RAWSXP && EXTPTR_PTR(o) == NULL) {
     JNIEnv *env = getJNIEnv();
@@ -174,7 +174,7 @@ HIDE void deserializeSEXP(SEXP o) {
 	}
 	releaseObject(env, ser);
       }
-    }    
+    }
   }
 }
 
@@ -206,7 +206,7 @@ HIDE void init_sigbuf(sig_buffer_t *sb) {
 }
 
 /* free the content of a signature buffer (if necessary) */
-HIDE void done_sigbuf(sig_buffer_t *sb) { 
+HIDE void done_sigbuf(sig_buffer_t *sb) {
   if (sb->sig != sb->sigbuf) free(sb->sig);
 }
 
@@ -228,7 +228,7 @@ static int Rpar2jvalue(JNIEnv *env, SEXP par, jvalue *jpar, sig_buffer_t *sig, i
 	    Rf_error("Too many arguments in Java call. maxJavaPars is %d, recompile rJava with higher number if needed.", maxJavaPars);
 	break;
     }
-    
+
     _dbg(rjprintf("Rpar2jvalue: par %d type %d\n",i,TYPEOF(e)));
     if (TYPEOF(e)==STRSXP) {
       _dbg(rjprintf(" string vector of length %d\n",LENGTH(e)));
@@ -430,10 +430,10 @@ REPE SEXP RcallMethod(SEXP par) {
   jmethodID mid = 0;
   jclass cls;
   JNIEnv *env = getJNIEnv();
-  
+
   profStart();
   p=CDR(p); e=CAR(p); p=CDR(p);
-  if (e==R_NilValue) 
+  if (e==R_NilValue)
     error_return("RcallMethod: call on a NULL object");
   if (TYPEOF(e)==EXTPTRSXP) {
     jverify(e);
@@ -465,7 +465,7 @@ REPE SEXP RcallMethod(SEXP par) {
   if (TYPEOF(e)==STRSXP && LENGTH(e)==1) { /* signature */
     retsig=CHAR_UTF8(STRING_ELT(e,0));
     /*
-      } else if (inherits(e, "jobjRef")) { method object 
+      } else if (inherits(e, "jobjRef")) { method object
     SEXP mexp = GET_SLOT(e, install("jobj"));
     jobject mobj = (jobject)(INTEGER(mexp)[0]);
     _dbg(rjprintf(" signature is Java object %x - using reflection\n", mobj);
@@ -473,7 +473,7 @@ REPE SEXP RcallMethod(SEXP par) {
     retsig = getReturnSigFromMethodObject(mobj);
     */
   } else error_return("RcallMethod: invalid return signature parameter");
-    
+
   e=CAR(p); p=CDR(p);
   if (TYPEOF(e)!=STRSXP || LENGTH(e)!=1)
     error_return("RcallMethod: invalid method name");
@@ -518,7 +518,7 @@ END_RJAVA_CALL
 BEGIN_RJAVA_CALL
     int r=o?
       (*env)->CallIntMethodA(env, o, mid, jpar):
-      (*env)->CallStaticIntMethodA(env, cls, mid, jpar);  
+      (*env)->CallStaticIntMethodA(env, cls, mid, jpar);
     e = allocVector(INTSXP, 1);
     INTEGER(e)[0] = r;
 END_RJAVA_CALL
@@ -553,7 +553,7 @@ END_RJAVA_CALL
     _prof(profReport("Method \"%s\" returned:",mnam));
     return e;
    }
- case 'J': { 
+ case 'J': {
 BEGIN_RJAVA_CALL
     jlong r=o?
       (*env)->CallLongMethodA(env, o, mid, jpar):
@@ -566,7 +566,7 @@ END_RJAVA_CALL
     _prof(profReport("Method \"%s\" returned:",mnam));
     return e;
  }
- case 'S': { 
+ case 'S': {
 BEGIN_RJAVA_CALL
     jshort r=o?
       (*env)->CallShortMethodA(env, o, mid, jpar):
@@ -640,7 +640,7 @@ END_RJAVA_CALL
   } /* switch */
   _prof(profReport("Method \"%s\" has an unknown signature, not called:",mnam));
   releaseObject(env, cls);
-  error("unsupported/invalid mathod signature %s", retsig);
+  error("unsupported/invalid method signature %s", retsig);
   return R_NilValue;
 }
 
@@ -651,7 +651,7 @@ REPE SEXP RcallSyncMethod(SEXP par) {
   JNIEnv *env=getJNIEnv();
 
   p=CDR(p); e=CAR(p); p=CDR(p);
-  if (e==R_NilValue) 
+  if (e==R_NilValue)
     error("RcallSyncMethod: call on a NULL object");
   if (TYPEOF(e)==EXTPTRSXP) {
     jverify(e);
@@ -748,7 +748,7 @@ END_RJAVA_CALL
     }
   }
 #endif
-  
+
   return j2SEXP(env, o, 1);
 }
 
@@ -796,7 +796,7 @@ HIDE SEXP new_jobjRef(JNIEnv *env, jobject o, const char *klass) {
   return oo;
 }
 
-/** 
+/**
  * creates a new jclassName object. similar to what the jclassName
  * function does in the R side
  *
@@ -817,9 +817,9 @@ HIDE SEXP new_jclassName(JNIEnv *env, jobject/*Class*/ cl ) {
 /** Calls the Class.getName method and return the result as an R STRSXP */
 HIDE SEXP getName( JNIEnv *env, jobject/*Class*/ cl){
 	char cn[128];
-	
+
 	jstring r = (*env)->CallObjectMethod(env, cl, mid_getName);
-  
+
 	cn[127]=0; *cn=0;
   	int sl = (*env)->GetStringLength(env, r);
   	if (sl>127) {
@@ -828,7 +828,7 @@ HIDE SEXP getName( JNIEnv *env, jobject/*Class*/ cl){
   	if (sl) (*env)->GetStringUTFRegion(env, r, 0, sl, cn);
   	char *c=cn; while(*c) { if (*c=='.') *c='/'; c++; }
 
-	SEXP res = PROTECT( mkString(cn ) ); 
+	SEXP res = PROTECT( mkString(cn ) );
 	releaseObject(env, r);
 	UNPROTECT(1); /* res */
 	return res;
@@ -852,7 +852,7 @@ static SEXP new_jarrayRef(JNIEnv *env, jobject a, const char *sig) {
 /**
  * Creates a reference to a rectangular java array.
  *
- * @param env 
+ * @param env
  * @param a the java object
  * @param sig signature (class of the array object)
  * @param dim dimension vector
@@ -869,7 +869,7 @@ static SEXP new_jrectRef(JNIEnv *env, jobject a, const char *sig, SEXP dim ) {
   SET_SLOT(oo, install("jclass"), mkString(sig));
   SET_SLOT(oo, install("jsig"), mkString(sig));
   SET_SLOT(oo, install("dimension"), dim);
-  
+
   UNPROTECT(1); /* oo */
   return oo;
 }
@@ -877,17 +877,17 @@ static SEXP new_jrectRef(JNIEnv *env, jobject a, const char *sig, SEXP dim ) {
 /* this does not take care of multi dimensional arrays properly */
 
 /**
- * Creates a one dimensionnal java array
+ * Creates a one dimensional java array
  *
  * @param an R list or vector
  * @param cl the class name
  */
 REPC SEXP RcreateArray(SEXP ar, SEXP cl) {
   JNIEnv *env=getJNIEnv();
-  
+
   if (ar==R_NilValue) return R_NilValue;
   switch(TYPEOF(ar)) {
-  case INTSXP:                                
+  case INTSXP:
     {
       if (inherits(ar, "jbyte")) {
 	jbyteArray a = newByteArrayI(env, INTEGER(ar), LENGTH(ar));
@@ -896,7 +896,7 @@ REPC SEXP RcreateArray(SEXP ar, SEXP cl) {
       } else if (inherits(ar, "jchar")) {
 	jcharArray a = newCharArrayI(env, INTEGER(ar), LENGTH(ar));
 	if (!a) error("unable to create a char array");
-	return new_jarrayRef(env, a, "[C" ); 
+	return new_jarrayRef(env, a, "[C" );
       } else if (inherits(ar, "jshort")) {
 	jshortArray a = newShortArrayI(env, INTEGER(ar), LENGTH(ar));
 	if (!a) error("unable to create a short integer array");
@@ -952,12 +952,12 @@ REPC SEXP RcreateArray(SEXP ar, SEXP cl) {
       jclass ac = javaObjectClass;
       const char *sigName = 0;
       char buf[256];
-      
+
       while (i<LENGTH(ar)) {
 	SEXP e = VECTOR_ELT(ar, i);
 	if (e != R_NilValue &&
 	    !inherits(e, "jobjRef") &&
-	    !inherits(e, "jarrayRef") && 
+	    !inherits(e, "jarrayRef") &&
 	    !inherits(e, "jrectRef") )
 	  error("Cannot create a Java array from a list that contains anything other than Java object references.");
 	i++;
@@ -977,7 +977,7 @@ REPC SEXP RcreateArray(SEXP ar, SEXP cl) {
 	      buf[0] = '[';
 	      strcpy(buf+1, cname);
 	    } else {
-	      buf[0] = '['; buf[1] = 'L'; 
+	      buf[0] = '['; buf[1] = 'L';
 	      strcpy(buf+2, cname);
 	      strcat(buf,";");
 	    }
@@ -1000,7 +1000,7 @@ REPC SEXP RcreateArray(SEXP ar, SEXP cl) {
 	      jverify(sref);
 	      o = (jobject)EXTPTR_PTR(sref);
 	    }
-	  }	  
+	  }
 	  (*env)->SetObjectArrayElement(env, a, i, o);
 	  i++;
 	}
@@ -1034,7 +1034,7 @@ END_RJAVA_CALL
 REP void RclearException() {
   JNIEnv *env=getJNIEnv();
 BEGIN_RJAVA_CALL
-  (*env)->ExceptionClear(env);  
+  (*env)->ExceptionClear(env);
 END_RJAVA_CALL
 }
 
@@ -1061,7 +1061,7 @@ REPC SEXP RthrowException(SEXP ex) {
 
   if (!inherits(ex, "jobjRef"))
     error("Invalid throwable object.");
-  
+
   exr=GET_SLOT(ex, install("jobj"));
   if (exr && TYPEOF(exr)==EXTPTRSXP) {
     jverify(exr);
@@ -1069,7 +1069,7 @@ REPC SEXP RthrowException(SEXP ex) {
   }
   if (!t)
     error("Throwable must be non-null.");
-  
+
 BEGIN_RJAVA_CALL
   tr = (*env)->Throw(env, t);
 END_RJAVA_CALL

--- a/src/fields.c
+++ b/src/fields.c
@@ -22,7 +22,7 @@ static char *classToJNI(const char *cl) {
   if (!strcmp(cl, "short"))   return strdup("S");
   if (!strcmp(cl, "float"))   return strdup("F");
   if (!strcmp(cl, "char"))    return strdup("C");
- 
+
   /* anything else is a real class -> wrap into L..; */
   char *jc = malloc(strlen(cl)+3);
   *jc='L';
@@ -133,7 +133,7 @@ REPC SEXP RgetField(SEXP obj, SEXP sig, SEXP name, SEXP trueclass) {
     retsig = CHAR(STRING_ELT(sig,0));
   }
   _dbg(rjprintf("field %s signature is %s\n",fnam,retsig));
-  
+
   if (o) { /* first try non-static fields */
     fid = (*env)->GetFieldID(env, cls, fnam, retsig);
     checkExceptionsX(env, 1);
@@ -243,7 +243,7 @@ REPC SEXP RgetField(SEXP obj, SEXP sig, SEXP name, SEXP trueclass) {
       if (detsig) free(detsig);
       return new_jobjRef(env, r, 0);
     }
-    if (*retsig=='L') { /* need to fix the class name */      
+    if (*retsig=='L') { /* need to fix the class name */
       char *d = strdup(retsig), *c = d;
       while (*c) { if (*c==';') { *c=0; break; }; c++; }
       rv = new_jobjRef(env, r, d+1);
@@ -313,7 +313,7 @@ REPC SEXP RsetField(SEXP ref, SEXP name, SEXP value) {
 #endif
   init_sigbuf(&sig);
   jval = R1par2jvalue(env, value, &sig, &otr);
-  
+
   if (o) {
     fid = (*env)->GetFieldID(env, cls, fnam, sig.sig);
     if (!fid) {
@@ -372,7 +372,7 @@ REPC SEXP RsetField(SEXP ref, SEXP name, SEXP value) {
     releaseObject(env, cls);
     if (otr) releaseObject(env, otr);
     done_sigbuf(&sig);
-    error("unknown field sighanture %s", sig.sigbuf);
+    error("unknown field siganture %s", sig.sigbuf);
   }
   done_sigbuf(&sig);
   releaseObject(env, cls);

--- a/src/init.c
+++ b/src/init.c
@@ -40,10 +40,10 @@ int rJava_initialized = 0;
 static int    jvm_opts=0;
 static char **jvm_optv=0;
 
-#ifdef JNI_VERSION_1_2 
+#ifdef JNI_VERSION_1_2
 static JavaVMOption *vm_options;
 static JavaVMInitArgs vm_args;
-#else  
+#else
 #error "Java/JNI 1.2 or higher is required!"
 #endif
 
@@ -101,16 +101,16 @@ static int initJVM(const char *user_classpath, int opts, char **optv, int hooks,
   int total_num_properties, propNum = 0;
   jint res;
   char *classpath;
-  
+
   if(!user_classpath)
     /* use the CLASSPATH environment variable as default */
     user_classpath = getenv("CLASSPATH");
   if(!user_classpath) user_classpath = "";
-  
+
   vm_args.version = JNI_VERSION_1_2;
   if(JNI_GetDefaultJavaVMInitArgs(&vm_args) != JNI_OK) {
     error("JNI 1.2 or higher is required");
-    return -1;    
+    return -1;
   }
 
   vm_args.version = JNI_VERSION_1_2; /* should we do that or keep the default? */
@@ -132,19 +132,19 @@ static int initJVM(const char *user_classpath, int opts, char **optv, int hooks,
 
   /* leave room for class.path, and optional jni args */
   total_num_properties = 8 + opts;
-    
+
   vm_options = (JavaVMOption *) calloc(total_num_properties, sizeof(JavaVMOption));
   vm_args.options = vm_options;
   vm_args.ignoreUnrecognized = disableGuardPages ? JNI_FALSE : JNI_TRUE;
-  
+
   classpath = (char*) calloc(24 + strlen(user_classpath), sizeof(char));
   sprintf(classpath, "-Djava.class.path=%s", user_classpath);
-  
-  vm_options[propNum++].optionString = classpath;   
-  
+
+  vm_options[propNum++].optionString = classpath;
+
   /*   print JNI-related messages */
   /* vm_options[propNum++].optionString = "-verbose:class,jni"; */
-  
+
   if (optv) {
     int i=0;
     while (i<opts) {
@@ -168,14 +168,14 @@ static int initJVM(const char *user_classpath, int opts, char **optv, int hooks,
 
   /* Create the Java VM */
   res = JNI_CreateJavaVM(&jvm,(void **)&eenv, &vm_args);
-  
+
   if (disableGuardPages && (res != 0 || !eenv))
     return -2; /* perhaps this VM does not allow disabling guard pages */
 
   if (res != 0)
     error("Cannot create Java virtual machine (%d)", res);
   if (!eenv)
-    error("Cannot obtain JVM environemnt");
+    error("Cannot obtain JVM environment");
 
 #if defined(_WIN64) || defined(_WIN32)
   _setmode(0, _O_TEXT);
@@ -237,8 +237,8 @@ HIDE void init_rJava(void) {
   jclass c;
   JNIEnv *env = getJNIEnv();
   if (!env) return; /* initJVMfailed, so we cannot proceed */
-  
-  /* get global classes. we make the references explicitely global (although unloading of String/Object is more than unlikely) */
+
+  /* get global classes. we make the references explicitly global (although unloading of String/Object is more than unlikely) */
   c=(*env)->FindClass(env, "java/lang/String");
   if (!c) error("unable to find the basic String class");
   javaStringClass=(*env)->NewGlobalRef(env, c);
@@ -265,17 +265,17 @@ HIDE void init_rJava(void) {
 
   mid_forName  = (*env)->GetStaticMethodID(env, javaClassClass, "forName", "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;");
   if (!mid_forName) error("cannot obtain Class.forName method ID");
-  
+
   mid_getName  = (*env)->GetMethodID(env, javaClassClass, "getName", "()Ljava/lang/String;");
   if (!mid_getName) error("cannot obtain Class.getName method ID");
-  
+
   mid_getSuperclass =(*env)->GetMethodID(env, javaClassClass, "getSuperclass", "()Ljava/lang/Class;");
   if (!mid_getSuperclass) error("cannot obtain Class.getSuperclass method ID");
-  
+
   mid_getField = (*env)->GetMethodID(env, javaClassClass, "getField",
 				     "(Ljava/lang/String;)Ljava/lang/reflect/Field;");
   if (!mid_getField) error("cannot obtain Class.getField method ID");
- 
+
   mid_getType  = (*env)->GetMethodID(env, javaFieldClass, "getType",
 				     "()Ljava/lang/Class;");
   if (!mid_getType) error("cannot obtain Field.getType method ID");
@@ -294,10 +294,10 @@ static SEXP RinitJVM_real(SEXP par, int disableGuardPages)
   int r=0;
   JavaVM *jvms[32];
   jsize vms=0;
-  
+
   jvm_opts=0;
   jvm_optv=0;
-  
+
   if (TYPEOF(e)==STRSXP && LENGTH(e)>0)
 	  c=CHAR(STRING_ELT(e,0));
 
@@ -337,7 +337,7 @@ static SEXP RinitJVM_real(SEXP par, int disableGuardPages)
   }
   if (jvm_opts)
       jvm_optv[jvm_opts] = 0;
-  
+
   r=JNI_GetCreatedJavaVMs(jvms, 32, &vms);
   if (r) {
     Rf_error("JNI_GetCreatedJavaVMs returned %d\n", r);
@@ -468,7 +468,7 @@ extern int R_CStackDir;
   bound is the new first address not to access
   dir is 1 (stack grows up) or -1 (stack grows down, the usual)
     so, incrementing by dir one traverses from stack start, from the oldest
-    things on the stace; note that in R_CStackDir, 1 means stack grows down
+    things on the stack; note that in R_CStackDir, 1 means stack grows down
 
   returns NULL in case of error, limit when no new limit is found,
     a new limit when found
@@ -503,7 +503,7 @@ static char* findBound(char *from, char *limit, int dir)
     _exit(0);
   } else {
     /* Parent process, writes data to the pipe looking for EFAULT error which
-       indicates an inaccesible page. For performance, the reading is first
+       indicates an inaccessible page. For performance, the reading is first
        done using a buffer (of the size of a page), but once EFAULT is reached,
        it is re-tried byte-by-byte for the last buffer not read successfully.
     */
@@ -749,52 +749,51 @@ REP void doneJVM() {
  * Initializes the cached values of classes and methods used internally
  * These classes and methods are the ones that are in rJava (RJavaTools, ...)
  * not java standard classes (Object, Class)
- */ 
+ */
 REPC SEXP initRJavaTools(){
 
 	JNIEnv *env=getJNIEnv();
-	jclass c; 
-	
+	jclass c;
+
 	/* classes */
-	
+
 	/* RJavaTools class */
 	c = findClass(env, "RJavaTools", oClassLoader);
 	if (!c) error("unable to find the RJavaTools class");
 	rj_RJavaTools_Class=(*env)->NewGlobalRef(env, c);
 	if (!rj_RJavaTools_Class) error("unable to create a global reference to the RJavaTools class");
 	(*env)->DeleteLocalRef(env, c);
-	
+
 	/* RJavaImport */
-	c = findClass(env, "RJavaImport", oClassLoader); 
+	c = findClass(env, "RJavaImport", oClassLoader);
 	if (!c) error("unable to find the RJavaImport class");
 	rj_RJavaImport_Class=(*env)->NewGlobalRef(env, c);
 	if (!rj_RJavaImport_Class) error("unable to create a global reference to the RJavaImport class");
 	(*env)->DeleteLocalRef(env, c);
-	
-	
+
+
 	/* methods */
-	
-	mid_RJavaTools_getFieldTypeName  = (*env)->GetStaticMethodID(env, rj_RJavaTools_Class, 
+
+	mid_RJavaTools_getFieldTypeName  = (*env)->GetStaticMethodID(env, rj_RJavaTools_Class,
 		"getFieldTypeName", "(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/String;");
 	if (!mid_RJavaTools_getFieldTypeName) error("cannot obtain RJavaTools.getFieldTypeName method ID");
-	
-	mid_rj_getSimpleClassNames  = (*env)->GetStaticMethodID(env, rj_RJavaTools_Class, 
+
+	mid_rj_getSimpleClassNames  = (*env)->GetStaticMethodID(env, rj_RJavaTools_Class,
 		"getSimpleClassNames", "(Ljava/lang/Object;Z)[Ljava/lang/String;");
 	if (!mid_rj_getSimpleClassNames) error("cannot obtain RJavaTools.getDimpleClassNames method ID");
-	
-	mid_RJavaImport_getKnownClasses = (*env)->GetMethodID(env, rj_RJavaImport_Class, 
+
+	mid_RJavaImport_getKnownClasses = (*env)->GetMethodID(env, rj_RJavaImport_Class,
 		"getKnownClasses", "()[Ljava/lang/String;");
 	if (!mid_RJavaImport_getKnownClasses) error("cannot obtain RJavaImport.getKnownClasses method ID");
-	
-	mid_RJavaImport_lookup = (*env)->GetMethodID(env, rj_RJavaImport_Class, 
+
+	mid_RJavaImport_lookup = (*env)->GetMethodID(env, rj_RJavaImport_Class,
 		"lookup", "(Ljava/lang/String;)Ljava/lang/Class;");
 	if( !mid_RJavaImport_lookup) error("cannot obtain RJavaImport.lookup method ID");
-	
-	mid_RJavaImport_exists = (*env)->GetMethodID(env, rj_RJavaImport_Class, 
+
+	mid_RJavaImport_exists = (*env)->GetMethodID(env, rj_RJavaImport_Class,
 		"exists", "(Ljava/lang/String;)Z");
 	if( ! mid_RJavaImport_exists ) error("cannot obtain RJavaImport.exists method ID");
 	// maybe add RJavaArrayTools, ...
-	
-	return R_NilValue; 
-}
 
+	return R_NilValue;
+}

--- a/src/jri_glue.c
+++ b/src/jri_glue.c
@@ -2,7 +2,7 @@
 #include <Rinternals.h>
 #include "rJava.h"
 
-/* creates a reference to an R object on the Java side 
+/* creates a reference to an R object on the Java side
    1) lock down the object in R
    2) call new Rengine(eng,robj) {or any other class such as REXPReference for REngine API}
  */
@@ -13,7 +13,7 @@ REPC SEXP PushToREXP(SEXP clname, SEXP eng, SEXP engCl, SEXP robj, SEXP doConv) 
   int convert = (doConv == R_NilValue) ? -1 : asInteger(doConv);
   JNIEnv *env=getJNIEnv();
   const char *cName;
-  
+
   if (!isString(clname) || LENGTH(clname)!=1) error("invalid class name");
   if (!isString(engCl) || LENGTH(engCl)!=1) error("invalid engine class name");
   if (TYPEOF(eng)!=EXTPTRSXP) error("invalid engine object");
@@ -31,7 +31,7 @@ REPC SEXP PushToREXP(SEXP clname, SEXP eng, SEXP engCl, SEXP robj, SEXP doConv) 
   o = createObject(env, cName, sig, jpar, 1, 0);
   if (!o) error("Unable to create Java object");
   return j2SEXP(env, o, 1);
-  /* ok, some thoughts on mem mgmt - j2SEXP registers a finalizer. But I believe that is ok, because the pushed reference is useless until it is passed as an argument to some Java method. And then, it will have another reference which will prevent the Java side from being collected. The R-side reference may be gone, but that's ok, because it's the Java finalizer that needs to clean up the pushed R object and for that it doesn't need the proxy object at all. This is the reason why RReleaseREXP uses EXTPTR - all the Java finalizaer has to do is to call RReleaseREXP(self). For that it can create a fresh proxy object containing the REXP. But here comes he crux - this proxy cannot again create a reference - it must be plain pass-through, so this part needs to be verified.
+  /* ok, some thoughts on mem mgmt - j2SEXP registers a finalizer. But I believe that is ok, because the pushed reference is useless until it is passed as an argument to some Java method. And then, it will have another reference which will prevent the Java side from being collected. The R-side reference may be gone, but that's ok, because it's the Java finalizer that needs to clean up the pushed R object and for that it doesn't need the proxy object at all. This is the reason why RReleaseREXP uses EXTPTR - all the Java finalizer has to do is to call RReleaseREXP(self). For that it can create a fresh proxy object containing the REXP. But here comes he crux - this proxy cannot again create a reference - it must be plain pass-through, so this part needs to be verified.
 
 Note: as of REngine API the references assume protected objects and use rniRelease to clean up, so RReleaseREXP won't be called and is not needed. That is good, because RReleaseREXP assumes JRI objects whereas REngine will create REXPReference (no xp there). However, if we ever change that REXPReference assumption we will be in trouble.
  */
@@ -56,5 +56,3 @@ REPC SEXP RReleaseREXP(SEXP ptr) {
   }
   return R_NilValue;
 }
-
-    

--- a/src/otables.c
+++ b/src/otables.c
@@ -15,38 +15,38 @@ HIDE SEXP R_getUnboundValue() {
 /**
  * @param name name of a java class
  * @param canCache Can R cache this object
- * @param tb 
+ * @param tb
  * @return TRUE if the a class called name exists in on of the packages
  */
 /* not actually used by R */
 HIDE Rboolean rJavaLookupTable_exists(const char * const name, Rboolean *canCache, R_ObjectTable *tb){
 
 #ifdef LOOKUP_DEBUG
- Rprintf( "  >> rJavaLookupTable_exists\n" ); 
+ Rprintf( "  >> rJavaLookupTable_exists\n" );
 #endif
-	
+
  if(tb->active == FALSE)
     return(FALSE);
 
  tb->active = FALSE;
  Rboolean val = classNameLookupExists( tb, name );
  tb->active = TRUE;
- 
+
  return( val );
 }
 
 /**
- * Returns a new jclassName object if the class exists or the 
+ * Returns a new jclassName object if the class exists or the
  * unbound value if it does not
  *
  * @param name class name
- * @param canCache ?? 
+ * @param canCache ??
  * @param tb lookup table
  */
 SEXP rJavaLookupTable_get(const char * const name, Rboolean *canCache, R_ObjectTable *tb){
 
 #ifdef LOOKUP_DEBUG
- Rprintf( "  >> rJavaLookupTable_get\n" ); 
+ Rprintf( "  >> rJavaLookupTable_get\n" );
 #endif
 
  SEXP val;
@@ -57,7 +57,7 @@ SEXP rJavaLookupTable_get(const char * const name, Rboolean *canCache, R_ObjectT
  val = PROTECT( classNameLookup( tb, name ) );
  tb->active = TRUE;
 
- UNPROTECT(1); /* val */ 
+ UNPROTECT(1); /* val */
  return(val);
 }
 
@@ -66,23 +66,23 @@ SEXP rJavaLookupTable_get(const char * const name, Rboolean *canCache, R_ObjectT
  */
 int rJavaLookupTable_remove(const char * const name,  R_ObjectTable *tb){
 #ifdef LOOKUP_DEBUG
- Rprintf( "  >> rJavaLookupTable_remove( %s) \n", name ); 
+ Rprintf( "  >> rJavaLookupTable_remove( %s) \n", name );
 #endif
 	error( "cannot remove from java package" ) ;
 	return 0;
 }
 
 /**
- * Indicates if R can cahe the variable name. 
- * Currently allways return FALSE
+ * Indicates if R can cache the variable name.
+ * Currently always return FALSE
  *
  * @param name name of the class
  * @param tb lookup table
- * @return allways FALSE (for now)
- */ 
+ * @return always FALSE (for now)
+ */
 HIDE Rboolean rJavaLookupTable_canCache(const char * const name, R_ObjectTable *tb){
 #ifdef LOOKUP_DEBUG
- Rprintf( "  >> rJavaLookupTable_canCache\n" ); 
+ Rprintf( "  >> rJavaLookupTable_canCache\n" );
 #endif
 	return( FALSE );
 }
@@ -92,34 +92,34 @@ HIDE Rboolean rJavaLookupTable_canCache(const char * const name, R_ObjectTable *
  */
 HIDE SEXP rJavaLookupTable_assign(const char * const name, SEXP value, R_ObjectTable *tb){
 #ifdef LOOKUP_DEBUG
- Rprintf( "  >> rJavaLookupTable_assign( %s ) \n", name ); 
+ Rprintf( "  >> rJavaLookupTable_assign( %s ) \n", name );
 #endif
     error("can't assign to java package lookup");
     return R_NilValue;
 }
 
 /**
- * Returns the list of classes known to be included in the 
+ * Returns the list of classes known to be included in the
  * packages. Currently returns NULL
  *
  * @param tb lookup table
- */ 
+ */
 HIDE SEXP rJavaLookupTable_objects(R_ObjectTable *tb) {
 #ifdef LOOKUP_DEBUG
- Rprintf( "  >> rJavaLookupTable_objects\n" ); 
+ Rprintf( "  >> rJavaLookupTable_objects\n" );
 #endif
-	
+
 	tb->active = FALSE;
-	SEXP res = PROTECT( getKnownClasses( tb ) ) ; 
+	SEXP res = PROTECT( getKnownClasses( tb ) ) ;
 	tb->active = TRUE;
 	UNPROTECT(1); /* res */
-	return( res ); 
+	return( res );
 }
 
 
 REPC SEXP newRJavaLookupTable(SEXP importer){
 #ifdef LOOKUP_DEBUG
- Rprintf( "<newRJavaLookupTable>\n" ); 
+ Rprintf( "<newRJavaLookupTable>\n" );
 #endif
 
  R_ObjectTable *tb;
@@ -128,12 +128,12 @@ REPC SEXP newRJavaLookupTable(SEXP importer){
   tb = (R_ObjectTable *) malloc(sizeof(R_ObjectTable));
   if(!tb)
       error( "cannot allocate space for an internal R object table" );
-  
+
   tb->type = RJAVA_LOOKUP ; /* FIXME: not sure what this should be */
   tb->cachedNames = NULL;
-  
-  R_PreserveObject(importer); 
-  tb->privateData = importer; 
+
+  R_PreserveObject(importer);
+  tb->privateData = importer;
 
   tb->exists = rJavaLookupTable_exists;
   tb->get = rJavaLookupTable_get;
@@ -152,7 +152,7 @@ REPC SEXP newRJavaLookupTable(SEXP importer){
   UNPROTECT(2);
 
 #ifdef LOOKUP_DEBUG
- Rprintf( "</newRJavaLookupTable>\n" ); 
+ Rprintf( "</newRJavaLookupTable>\n" );
 #endif
   return(val);
 }
@@ -160,38 +160,38 @@ REPC SEXP newRJavaLookupTable(SEXP importer){
 
 HIDE jobject getImporterReference(R_ObjectTable *tb ){
 	jobject res = (jobject)EXTPTR_PTR( GET_SLOT( (SEXP)(tb->privateData), install( "jobj" ) ) );
-	
+
 #ifdef LOOKUP_DEBUG
-	Rprintf( "  >> getImporterReference : [%d]\n", res ); 
+	Rprintf( "  >> getImporterReference : [%d]\n", res );
 #endif
 	return res ;
 }
 
 HIDE SEXP getKnownClasses( R_ObjectTable *tb ){
 #ifdef LOOKUP_DEBUG
- Rprintf( "  >> getKnownClasses\n" ); 
+ Rprintf( "  >> getKnownClasses\n" );
 #endif
-	jobject importer = getImporterReference(tb); 
-	
+	jobject importer = getImporterReference(tb);
+
 	JNIEnv *env=getJNIEnv();
 	jarray a = (jarray) (*env)->CallObjectMethod(env, importer, mid_RJavaImport_getKnownClasses ) ;
 	SEXP res = PROTECT( getStringArrayCont( a ) ) ;
-	
+
 #ifdef LOOKUP_DEBUG
- Rprintf( "    %d known classes\n", LENGTH(res) ); 
+ Rprintf( "    %d known classes\n", LENGTH(res) );
 #endif
-	
-	UNPROTECT(1); 
+
+	UNPROTECT(1);
 	return res ;
 }
 
 HIDE SEXP classNameLookup( R_ObjectTable *tb, const char * const name ){
 #ifdef LOOKUP_DEBUG
- Rprintf( " >> classNameLookup\n" ); 
+ Rprintf( " >> classNameLookup\n" );
 #endif
 	JNIEnv *env=getJNIEnv();
-	
-	jobject importer = getImporterReference(tb); 
+
+	jobject importer = getImporterReference(tb);
 
 	jobject clazz = newString(env, name ) ;
 	jstring s ; /* Class */
@@ -200,42 +200,41 @@ HIDE SEXP classNameLookup( R_ObjectTable *tb, const char * const name ){
 	int np ;
 	if( !s ){
 		res = R_getUnboundValue() ;
-		np = 0; 
+		np = 0;
 	} else{
 		PROTECT( res = new_jclassName( env, s ) );
-		np = 1; 
+		np = 1;
 	}
 
 	releaseObject(env, clazz);
 	releaseObject(env, s);
-    
-	if( np ) UNPROTECT(1); 
+
+	if( np ) UNPROTECT(1);
 #ifdef LOOKUP_DEBUG
- Rprintf( "</classNameLookup>\n" ); 
+ Rprintf( "</classNameLookup>\n" );
 #endif
-	return res ; 
+	return res ;
 }
 
 HIDE Rboolean classNameLookupExists(R_ObjectTable *tb, const char * const name ){
 #ifdef LOOKUP_DEBUG
- Rprintf( " classNameLookupExists\n" ); 
+ Rprintf( " classNameLookupExists\n" );
 #endif
-	
+
 	JNIEnv *env=getJNIEnv();
-	
-	jobject importer = getImporterReference(tb); 
+
+	jobject importer = getImporterReference(tb);
 	jobject clazz = newString(env, name ) ;
-	
+
 	jboolean s ; /* Class */
-	s = (jboolean) (*env)->CallBooleanMethod(env, importer, 
+	s = (jboolean) (*env)->CallBooleanMethod(env, importer,
 		mid_RJavaImport_exists , clazz ) ;
-	Rboolean res = (s) ? TRUE : FALSE; 
+	Rboolean res = (s) ? TRUE : FALSE;
 
 #ifdef LOOKUP_DEBUG
- Rprintf( "    exists( %s ) = %d \n", name, res ); 
+ Rprintf( "    exists( %s ) = %d \n", name, res );
 #endif
-	
+
 	releaseObject(env, clazz);
     return res ;
 }
-

--- a/src/rJava.c
+++ b/src/rJava.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* determine whether eenv chache should be used (has no effect if JNI_CACHE is not set) */
+/* determine whether eenv cache should be used (has no effect if JNI_CACHE is not set) */
 int use_eenv = 1;
 
 /* cached environment. Do NOT use directly! Always use getJNIEnv()! */
@@ -23,10 +23,10 @@ JNIEnv *eenv;
 typedef int sigset_t;
 #endif  /* Not _SIGSET_T_ */
 typedef struct
-{    
-  jmp_buf jmpbuf;     /* Calling environment.  */  
-  int mask_was_saved;       /* Saved the signal mask?  */                   
-  sigset_t saved_mask;      /* Saved signal mask.  */                       
+{
+  jmp_buf jmpbuf;     /* Calling environment.  */
+  int mask_was_saved;       /* Saved the signal mask?  */
+  sigset_t saved_mask;      /* Saved signal mask.  */
 } sigjmp_buf[1];
 /* we need to set HAVE_POSIX_SETJMP since we don't have config.h on Win */
 #ifndef HAVE_POSIX_SETJMP
@@ -70,7 +70,7 @@ static SEXP getCurrentCall() {
 		ctx = ctx->nextcontext;
 	/* skip .jcheck */
 	if (TYPEOF(ctx->call) == LANGSXP && CAR(ctx->call) == install(".jcheck") && ctx->nextcontext)
-		ctx = ctx->nextcontext;		
+		ctx = ctx->nextcontext;
 	return ctx->call;
 }
 #else
@@ -82,7 +82,7 @@ static SEXP getCurrentCall() {
 
 /** throw an exception using R condition code.
  *  @param msg - message string
- *  @param jobj - jobjRef object of the exception 
+ *  @param jobj - jobjRef object of the exception
  *  @param clazzes - simple name of all the classes in the inheritance tree of the exception plus "error" and "condition"
  */
 HIDE void throwR(SEXP msg, SEXP jobj, SEXP clazzes) {
@@ -94,7 +94,7 @@ HIDE void throwR(SEXP msg, SEXP jobj, SEXP clazzes) {
 	SET_STRING_ELT(names, 0, mkChar("message"));
 	SET_STRING_ELT(names, 1, mkChar("call"));
 	SET_STRING_ELT(names, 2, mkChar("jobj"));
-	
+
 	setAttrib(cond, R_NamesSymbol, names);
 	setAttrib(cond, R_ClassSymbol, clazzes);
 	UNPROTECT(2); /* clazzes, names */
@@ -104,7 +104,7 @@ HIDE void throwR(SEXP msg, SEXP jobj, SEXP clazzes) {
 
 /* check for exceptions and throw them to R level */
 HIDE void ckx(JNIEnv *env) {
-	SEXP xr, xobj, msg = 0, xclass = 0; /* note: we don't bother counting protections becasue we never return */
+	SEXP xr, xobj, msg = 0, xclass = 0; /* note: we don't bother counting protections because we never return */
 	jthrowable x = 0;
 	if (env && !(x = (*env)->ExceptionOccurred(env))) return;
 	if (!env) {
@@ -115,19 +115,19 @@ HIDE void ckx(JNIEnv *env) {
 		return;
 	}
 	/* env is valid and an exception occurred */
-	/* we create the jobj first, because the exception may in theory disappear after being cleared, 
+	/* we create the jobj first, because the exception may in theory disappear after being cleared,
 	   yet this can be (also in theory) risky as it uses further JNI calls ... */
 	xobj = j2SEXP(env, x, 0);
 	if (!rj_RJavaTools_Class) {
 	    /* temporary warning due the JDK 12 breakage */
-	    REprintf("WARNING: Initial Java 12 release has broken JNI support and does NOT work. Use stable Java 11 (or watch for 12u if avaiable).\nERROR: Java exception occurred during rJava bootstrap - see stderr for Java stack trace.\n");
+	    REprintf("WARNING: Initial Java 12 release has broken JNI support and does NOT work. Use stable Java 11 (or watch for 12u if available).\nERROR: Java exception occurred during rJava bootstrap - see stderr for Java stack trace.\n");
 	    (*env)->ExceptionDescribe(env);
 	}
 	(*env)->ExceptionClear(env);
-	
+
 	/* grab the list of class names (without package path) */
 	SEXP clazzes = rj_RJavaTools_Class ? PROTECT( getSimpleClassNames_asSEXP( (jobject)x, (jboolean)1 ) ) : R_NilValue;
-	
+
 	/* ok, now this is a critical part that we do manually to avoid recursion */
 	{
 		jclass cls = (*env)->GetObjectClass(env, x);
@@ -148,14 +148,14 @@ HIDE void ckx(JNIEnv *env) {
 			cname = (jstring) (*env)->CallObjectMethod(env, cls, mid_getName);
 			if (cname) {
 				const char *c = (*env)->GetStringUTFChars(env, cname, 0);
-				if (c) {                          
+				if (c) {
 					/* convert full class name to JNI notation */
 					char *cn = strdup(c), *d = cn;
 					while (*d) { if (*d == '.') *d = '/'; d++; }
 					xclass = mkString(cn);
 					free(cn);
 					(*env)->ReleaseStringUTFChars(env, cname, c);
-				}		
+				}
 				(*env)->DeleteLocalRef(env, cname);
 			}
 			if ((*env)->ExceptionOccurred(env))
@@ -174,7 +174,7 @@ HIDE void ckx(JNIEnv *env) {
 		SET_SLOT(xr, install("jclass"), xclass ? xclass : mkString("java/lang/Throwable"));
 		SET_SLOT(xr, install("jobj"), xobj);
 	}
-	
+
 	/* and off to R .. (we're keeping xr and clazzes protected) */
 	throwR(msg, xr, clazzes);
 	/* throwR never returns so don't even bother ... */
@@ -216,7 +216,7 @@ HIDE JNIEnv *getJNIEnv()
       error("AttachCurrentThread failed! (result:%d)", (int)res); return 0;
     }
     if (env && !eenv) eenv=env;
-    
+
     /* if (eenv!=env)
         fprintf(stderr, "Warning! eenv=%x, but env=%x - different environments encountered!\n", eenv, env); */
     return env;

--- a/tests/leaks.R
+++ b/tests/leaks.R
@@ -14,7 +14,7 @@ cat(" running R gc\n")
 gc()
 cat(" running java GC\n")
 cat(.jcall("Leaks","S","reportMem"),"\n")
-cat(" - static pass thorugh parameters\n")
+cat(" - static pass through parameters\n")
 for (i in 1:800) {
   if (i==400) { cat('   (forcing R gc)\n'); gc() }
   .i <- .jcall("Leaks", "[I", "passI", .i)


### PR DESCRIPTION
Originally saw the typo in rJava.c as I'd installed JDK12 on my new machine.

Decided while I'm at it to run

```
aspell(list.files('man', full.names = TRUE), filter = 'Rd')
aspell(list.files('R', full.names = TRUE, pattern = '\\.R$'), filter = 'R')
aspell(list.files('src', full.names = TRUE))
aspell('NEWS')
aspell(list.files('tests', full.names = TRUE))
```

And found the following typos in there. Cheers.