### PR TITLE
Cache getNativeSymbolInfo for Interface calls

### DIFF
--- a/R/jfirst.R
+++ b/R/jfirst.R
@@ -25,7 +25,9 @@
                      # .External
                     "RcreateObject", "RgetStringValue", "RinitJVM", "RtoString",
                      # .C
-                    "RclearException", "RuseJNICache"
+                    "RclearException", "RuseJNICache",
+                     # Interfaces
+                    "RcallMethod", "RcallSyncMethod"
                     )
 
 .jfirst <- function(libname, pkgname) {


### PR DESCRIPTION
* I suspect this was always supposed to happen but just got missed
* for me this changes the simple call in .jcall example from 30-35 µs to 15-20 µs per call.
* see #221