### PR TITLE
Fixed "yield" usage for Java 13+

### DIFF
--- a/jri/Rengine.java
+++ b/jri/Rengine.java
@@ -117,7 +117,7 @@ public class Rengine extends Thread {
         mainEngine=this;
 	mainRThread=this;
         start();
-        while (!alive && !died) yield();
+        while (!alive && !died) super.yield();
     }
 
     /** create a new engine by hooking into an existing, initialized R instance which is calling this constructor. Currently JRI won't influence this R instance other than disabling stack checks (i.e. no callbacks can be registered etc.). It is *not* the designated constructor and it should be used *only* from withing rJava.


### PR DESCRIPTION
As specified in [JEP 354](https://docs.oracle.com/javase/specs/jls/se13/preview/switch-expressions.html#jep354-3.9), starting from Java 13+, calls to methods named "yield" must be qualified to be distinguished from a yield statement.