### PR TITLE
Add .prepare script for CI services

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,3 @@
+\.github$
+\.prepare$
+\.git$

--- a/.prepare
+++ b/.prepare
@@ -1,0 +1,3 @@
+#!/bin/sh
+sh mkdist
+(cd .. ; tar xzvf rJava_*.tar.gz) 


### PR DESCRIPTION
This would allow us to build the package on https://s-u.r-universe.dev

The problem is that rJava is one of the few R packages that needs pre-work before we can run R CMD build. So we introduce a `.prepare` script which is run by the server directly after cloning the repo, in order to get the directory into the state it contains the source package, so then all the standard tooling works.

The current script is a minimal solution, perhaps there is a more elegant way by factoring out stuff from your `mkdist`.

Thanks!


