### PR TITLE
configure: Avoid implicit int in inline keyword check

### DIFF
--- a/configure
+++ b/configure
@@ -3624,7 +3624,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 static inline int foo(int a, int b);
-static f = 1;
+static int f = 1;
 static inline int foo(int a, int b) { return a+b; }
 int main(void) {
     return foo(f,-1);

--- a/configure.ac
+++ b/configure.ac
@@ -104,7 +104,7 @@ AS_MESSAGE([checking whether ${CC} supports static inline...])
 can_inline=no
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
 static inline int foo(int a, int b);
-static f = 1;
+static int f = 1;
 static inline int foo(int a, int b) { return a+b; }
 int main(void) {
     return foo(f,-1);


### PR DESCRIPTION
This prevents the check from going wrong with future compilers which do not support implicit ints.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
