### PR TITLE
Remove default -Xmx512m JVM parameter in rJava

### DIFF
--- a/R/jfirst.R
+++ b/R/jfirst.R
@@ -46,10 +46,6 @@
   for (x in .delayed.variables) assign(x, NULL, .env)
   assign(".jniInitialized", FALSE, .env)
 
-  # default JVM initialization parameters
-  if (is.null(getOption("java.parameters")))
-    options("java.parameters"="-Xmx512m")
-  
   ## S4 classes update - all classes are created earlier in classes.R, but jobjRef's prototype is only valid after the dylib is loaded
   setClass("jobjRef", representation(jobj="externalptr", jclass="character"), prototype=list(jobj=.jzeroRef, jclass="java/lang/Object"), where=.env)  
 }


### PR DESCRIPTION
This PR removes the default JVM initialization parameter `-Xmx512m` from the `jfirst.R` file. The reason for this change is that when no `java.parameters` option is defined, `rJava` imposes `-Xmx512m`, which silently overrides the default behaviour of the JVM initialization. 

By removing this hardcoded parameter, the JVM will initialize with its default heap settings when no parameters are explicitly defined, preserving the expected default behaviour of the JVM.