### PR TITLE
Typo in Java12 error

### DIFF
--- a/src/rJava.c
+++ b/src/rJava.c
@@ -120,7 +120,7 @@ HIDE void ckx(JNIEnv *env) {
 	xobj = j2SEXP(env, x, 0);
 	if (!rj_RJavaTools_Class) {
 	    /* temporary warning due the JDK 12 breakage */
-	    REprintf("WARNING: Initial Java 12 release has broken JNI support and does NOT work. Use stable Java 11 (or watch for 12u if avaiable).\nERROR: Java exception occurred during rJava bootstrap - see stderr for Java stack trace.\n");
+	    REprintf("WARNING: Initial Java 12 release has broken JNI support and does NOT work. Use stable Java 11 (or watch for 12u if available).\nERROR: Java exception occurred during rJava bootstrap - see stderr for Java stack trace.\n");
 	    (*env)->ExceptionDescribe(env);
 	}
 	(*env)->ExceptionClear(env);


### PR DESCRIPTION
Turns out I filed this PR many years ago... against myself 🤦 

https://github.com/MichaelChirico/rJava/pull/1

The patch still applies cleanly to current `master` so I'm refiling it where it belongs.