### PR TITLE
Drop ancient check for utils::.DollarNames

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -32,7 +32,7 @@ S3method(within, jclassName)
 # within requires that with.jobjRef is visible outside
 export(with.jobjRef)
 
-if( exists( ".DollarNames", asNamespace("utils") ) ) importFrom( utils, .DollarNames )
+importFrom( utils, .DollarNames )
 S3method(.DollarNames, jobjRef)
 S3method(.DollarNames, jarrayRef)
 S3method(.DollarNames, jrectRef)


### PR DESCRIPTION
This has been available since R 3.0.0, whereas {rJava} requires R 3.6.0:

https://github.com/wch/r-source/blob/b592ab7ef64945f4bef70e58134b347588e7e6ae/src/library/utils/R/completion.R#L50-L51

Found when checking for `exists()` in NAMESPACE files, which only happens twice on CRAN